### PR TITLE
[TASK] 5-1: Gradle 프로젝트 초기화 및 의존성 설정

### DIFF
--- a/springProject/build.gradle
+++ b/springProject/build.gradle
@@ -1,16 +1,16 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.7'
+    id 'org.springframework.boot' version '3.2.5'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.teambind'
 version = '0.0.1-SNAPSHOT'
-description = 'teambind reservation service server'
+description = 'Reservation Pricing Service - Hexagonal Architecture with DDD'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
@@ -25,13 +25,29 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter'
-    // cause -> ObjectMapper
+    // Spring Boot Starters
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Database
+    runtimeOnly 'org.postgresql:postgresql'
+    implementation 'org.flywaydb:flyway-core'
+
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+
+    // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Test - H2 for integration tests
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/springProject/src/test/resources/application.properties
+++ b/springProject/src/test/resources/application.properties
@@ -1,0 +1,17 @@
+# Test Database Configuration (H2 in-memory)
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# JPA Configuration
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+# Flyway Configuration (disabled for tests)
+spring.flyway.enabled=false
+
+# Kafka Configuration (disabled for tests)
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.consumer.auto-offset-reset=earliest


### PR DESCRIPTION
## Summary
Issue #5의 첫 번째 세부 작업으로 Gradle 프로젝트 초기화 및 의존성 설정을 완료했습니다.

## Changes
- Java 17 → Java 21 업그레이드
- Spring Boot 3.5.7 → 3.2.5 다운그레이드 (요구사항 명세에 따름)
- PostgreSQL, JPA, Flyway 의존성 추가
- Spring Kafka 의존성 추가
- 테스트용 H2 in-memory DB 설정 추가
- Gradle 빌드 성공 확인
- 테스트 통과 확인

## Related Issues
Related to #5

## Test Plan
- [x] Gradle 빌드 성공 (./gradlew clean build)
- [x] 테스트 통과 (./gradlew test)
- [x] Java 21 toolchain 적용 확인

## Next Steps
- 5-2: Hexagonal Architecture 패키지 구조 생성