### PR TITLE
[TASK] 5-2: Hexagonal Architecture 패키지 구조 생성

### DIFF
--- a/springProject/PACKAGE_STRUCTURE.md
+++ b/springProject/PACKAGE_STRUCTURE.md
@@ -1,0 +1,295 @@
+# Hexagonal Architecture 패키지 구조
+
+이 프로젝트는 **Hexagonal Architecture (Port & Adapter Pattern)** 와 **Domain-Driven Design (DDD)** 를 기반으로 설계되었습니다.
+
+## 전체 패키지 구조
+
+```
+com.teambind.springproject/
+├── domain/                          # 도메인 레이어 (핵심 비즈니스 로직)
+│   ├── pricingpolicy/              # PricingPolicy Aggregate
+│   ├── product/                    # Product Aggregate
+│   ├── reservationpricing/         # ReservationPricing Aggregate
+│   └── shared/                     # Shared Kernel (공통 Value Objects)
+│
+├── application/                     # 애플리케이션 레이어 (Use Cases)
+│   ├── port/
+│   │   ├── in/                     # Inbound Ports (Use Case Interfaces)
+│   │   └── out/                    # Outbound Ports (Infrastructure Interfaces)
+│   ├── service/                    # Application Services (Use Case 구현체)
+│   │   ├── pricingpolicy/
+│   │   ├── product/
+│   │   └── reservationpricing/
+│   └── dto/                        # Data Transfer Objects
+│       ├── request/
+│       └── response/
+│
+├── adapter/                         # 어댑터 레이어 (Infrastructure)
+│   ├── in/                          # Inbound Adapters (Primary)
+│   │   └── web/                     # REST Controllers
+│   │       ├── pricingpolicy/
+│   │       ├── product/
+│   │       └── reservationpricing/
+│   └── out/                         # Outbound Adapters (Secondary)
+│       ├── persistence/             # JPA Repositories
+│       │   ├── pricingpolicy/
+│       │   ├── product/
+│       │   └── reservationpricing/
+│       └── messaging/               # Kafka Event Handlers
+│           └── event/
+│
+└── common/                          # 공통 유틸리티 및 설정
+    ├── config/                      # Spring Configuration
+    ├── exceptions/                  # 예외 처리
+    └── util/                        # 유틸리티 클래스
+```
+
+---
+
+## 레이어별 상세 설명
+
+### 1. Domain Layer (도메인 레이어)
+
+**위치:** `com.teambind.springproject.domain`
+
+**책임:**
+- 핵심 비즈니스 로직 구현
+- 도메인 규칙(Invariants) 강제
+- 외부 기술 스택에 의존하지 않음
+
+**구성 요소:**
+- **Aggregate Root**: 트랜잭션 일관성 경계를 정의하는 엔티티
+- **Entity**: 고유 식별자를 가진 도메인 객체
+- **Value Object**: 불변 객체, 속성의 조합으로 식별
+- **Domain Service**: 여러 Aggregate에 걸친 비즈니스 로직
+- **Repository Interface**: 영속성 추상화 (Port)
+
+**설계 원칙:**
+- ✅ 불변성(Immutability) 최대 활용
+- ✅ 외부 레이어에 의존하지 않음 (Dependency Inversion)
+- ✅ 도메인 규칙을 생성자 및 메서드에서 강제
+
+---
+
+#### 1.1 PricingPolicy Aggregate
+
+**위치:** `com.teambind.springproject.domain.pricingpolicy`
+
+**책임:**
+- 시간대별 예약 가격 정책 관리
+- 요일별, 시간대별 가격 차등 적용
+- 시간대 중복 검증
+
+**도메인 규칙:**
+- ❌ 같은 요일 내에서 시간대 중복 불가
+- ❌ 시작 시간 > 종료 시간
+- ❌ 가격 < 0원
+
+**주요 클래스:**
+- `PricingPolicy`: Aggregate Root
+- `TimeSlot`: Value Object (시간대)
+- `DayOfWeek`: Enum (요일)
+
+---
+
+#### 1.2 Product Aggregate
+
+**위치:** `com.teambind.springproject.domain.product`
+
+**책임:**
+- 추가상품 등록 및 관리
+- 적용 범위 관리 (플레이스/룸/예약별)
+- 재고 관리 (가용 수량, 총 수량)
+
+**도메인 규칙:**
+- ❌ 사용 수량 > 총 수량
+- ✅ PENDING 또는 CONFIRMED 상태만 재고 차감
+- ❌ 가격 < 0원
+
+**주요 클래스:**
+- `Product`: Aggregate Root
+- `ProductScope`: Value Object (적용 범위)
+- `ProductAvailabilityService`: Domain Service
+
+---
+
+#### 1.3 ReservationPricing Aggregate
+
+**위치:** `com.teambind.springproject.domain.reservationpricing`
+
+**책임:**
+- 예약 시점의 가격 정보 스냅샷 저장
+- 예약 총 가격 계산 (룸 가격 + 추가상품)
+- 가격 정책 변경 이력 관리
+
+**도메인 규칙:**
+- ✅ 예약 가격은 생성 후 변경 불가 (Immutable Snapshot)
+- ✅ 총 가격 = 룸 가격 + ∑(추가상품 가격)
+- ❌ 가격 < 0원
+
+**주요 클래스:**
+- `ReservationPricing`: Aggregate Root
+- `PricingItem`: Entity (가격 항목)
+
+---
+
+#### 1.4 Shared Kernel
+
+**위치:** `com.teambind.springproject.domain.shared`
+
+**포함 요소:**
+- `Money`: 금액 Value Object
+- `ReservationId`: 예약 ID Value Object
+- `RoomId`: 룸 ID Value Object
+- `PlaceId`: 플레이스 ID Value Object
+
+**설계 원칙:**
+- ✅ 모든 Value Object는 불변(Immutable)
+- ✅ equals/hashCode 구현
+- ✅ 생성자에서 유효성 검증
+
+---
+
+### 2. Application Layer (애플리케이션 레이어)
+
+**위치:** `com.teambind.springproject.application`
+
+**책임:**
+- Use Case 구현 및 조율
+- 트랜잭션 경계 정의
+- DTO ↔ Domain 변환
+
+**구성 요소:**
+- **Inbound Port**: Use Case 인터페이스 (Primary Port)
+- **Outbound Port**: Infrastructure 추상화 인터페이스 (Secondary Port)
+- **Application Service**: Use Case 구현체
+- **DTO**: 외부 레이어와 데이터 교환
+
+**설계 원칙:**
+- ✅ 얇은 레이어로 유지 (Thin Layer)
+- ✅ 비즈니스 로직은 도메인 레이어에 위임
+- ✅ Infrastructure 세부사항 모름 (Port를 통해 추상화)
+
+---
+
+### 3. Adapter Layer (어댑터 레이어)
+
+**위치:** `com.teambind.springproject.adapter`
+
+**책임:**
+- 외부 세계와 애플리케이션 연결
+- Port 구현 (Inbound/Outbound)
+- 기술 세부사항 처리
+
+#### 3.1 Inbound Adapter (Primary)
+
+**위치:** `com.teambind.springproject.adapter.in.web`
+
+**책임:**
+- HTTP 요청 → Command/Query 변환
+- Use Case 호출
+- 결과 → HTTP 응답 변환
+- 입력 Validation
+
+**예시:**
+```java
+@RestController
+@RequestMapping("/api/v1/pricing-policies")
+public class PricingPolicyController {
+    private final CreatePricingPolicyUseCase createPricingPolicyUseCase;
+
+    @PostMapping
+    public ResponseEntity<PricingPolicyResponse> createPricingPolicy(
+            @Valid @RequestBody CreatePricingPolicyRequest request) {
+        var command = CreatePricingPolicyCommand.from(request);
+        var response = createPricingPolicyUseCase.createPricingPolicy(command);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}
+```
+
+#### 3.2 Outbound Adapter (Secondary)
+
+**Persistence (JPA):**
+
+**위치:** `com.teambind.springproject.adapter.out.persistence`
+
+**책임:**
+- Domain Model ↔ JPA Entity 변환
+- Domain Repository Port 구현
+- 데이터베이스 접근 로직
+
+**Messaging (Kafka):**
+
+**위치:** `com.teambind.springproject.adapter.out.messaging`
+
+**책임:**
+- 도메인 이벤트 → Kafka 메시지 변환
+- Kafka 메시지 발행/수신
+- 이벤트 직렬화/역직렬화
+
+---
+
+## 의존성 규칙 (Dependency Rule)
+
+```
+┌─────────────────────────────────────────┐
+│         Adapter Layer (Outer)           │
+│  ┌───────────────────────────────────┐  │
+│  │   Application Layer (Middle)      │  │
+│  │  ┌─────────────────────────────┐  │  │
+│  │  │   Domain Layer (Core)       │  │  │
+│  │  │                             │  │  │
+│  │  │  ✅ No Dependencies          │  │  │
+│  │  └─────────────────────────────┘  │  │
+│  │         ↑                          │  │
+│  │         │ depends on               │  │
+│  └───────────────────────────────────┘  │
+│                ↑                         │
+│                │ depends on              │
+└─────────────────────────────────────────┘
+```
+
+**핵심 원칙:**
+- ✅ **Domain Layer**: 어떤 레이어에도 의존하지 않음
+- ✅ **Application Layer**: Domain Layer에만 의존
+- ✅ **Adapter Layer**: Application Layer (Port)에만 의존
+- ❌ **절대 금지**: 안쪽 레이어가 바깥쪽 레이어를 의존하는 것
+
+---
+
+## 개발 가이드
+
+### 새로운 기능 추가 시 순서
+
+1. **Domain Layer**: Aggregate, Entity, Value Object 구현
+2. **Application Layer**: Use Case Port 정의 및 Application Service 구현
+3. **Adapter Layer**: Controller, Repository Adapter 구현
+4. **Test**: 각 레이어별 단위 테스트 작성
+
+### 패키지 네이밍 규칙
+
+- **소문자** 사용
+- **복수형** 사용 (예: `products`, `pricingpolicies`)
+- **명확한 비즈니스 용어** 사용
+
+### 클래스 네이밍 규칙
+
+- **Aggregate Root**: 명사 (예: `PricingPolicy`)
+- **Value Object**: 명사 (예: `Money`, `TimeSlot`)
+- **Domain Service**: `xxxService` (예: `ProductAvailabilityService`)
+- **Application Service**: `xxxService` (예: `PricingPolicyService`)
+- **Controller**: `xxxController` (예: `PricingPolicyController`)
+- **Repository**: `xxxRepository` (예: `PricingPolicyRepository`)
+
+---
+
+## 참고 자료
+
+- [Hexagonal Architecture by Alistair Cockburn](https://alistair.cockburn.us/hexagonal-architecture/)
+- [Domain-Driven Design by Eric Evans](https://www.domainlanguage.com/ddd/)
+- [Clean Architecture by Robert C. Martin](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)
+
+---
+
+**Last Updated**: 2025-11-08

--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/web/package-info.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/web/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * Web Inbound Adapter (REST Controllers)
+ *
+ * HTTP 요청을 받아 Use Case를 호출하고, 응답을 반환하는 REST API Controller입니다.
+ *
+ * 책임:
+ * - HTTP 요청 → Command/Query 변환
+ * - Use Case 호출
+ * - 결과 → HTTP 응답 변환
+ * - HTTP 상태 코드 결정
+ * - 입력 Validation (Bean Validation)
+ *
+ * 설계 원칙:
+ * - RESTful API 설계 원칙 준수
+ * - 얇은 레이어로 유지 (비즈니스 로직 포함 금지)
+ * - 명확한 예외 처리 및 응답
+ */
+package com.teambind.springproject.adapter.in.web;

--- a/springProject/src/main/java/com/teambind/springproject/adapter/out/messaging/package-info.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/out/messaging/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Messaging Outbound Adapter (Kafka Event Handlers)
+ *
+ * Kafka를 통해 도메인 이벤트를 발행하고, 외부 이벤트를 수신하는 어댑터입니다.
+ *
+ * 책임:
+ * - 도메인 이벤트 → Kafka 메시지 변환
+ * - Kafka 메시지 발행 (Producer)
+ * - 외부 이벤트 수신 (Consumer)
+ * - 이벤트 직렬화/역직렬화
+ *
+ * 설계 원칙:
+ * - 멱등성 보장 (중복 이벤트 처리)
+ * - At-least-once 또는 Exactly-once 보장
+ * - 이벤트 스키마 버전 관리
+ */
+package com.teambind.springproject.adapter.out.messaging;

--- a/springProject/src/main/java/com/teambind/springproject/adapter/out/persistence/package-info.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/out/persistence/package-info.java
@@ -1,0 +1,23 @@
+/**
+ * Persistence Outbound Adapter (JPA Repositories)
+ *
+ * 도메인 객체를 데이터베이스에 저장하고 조회하는 영속성 어댑터입니다.
+ *
+ * 구성 요소:
+ * - JPA Entity: 데이터베이스 테이블과 매핑되는 클래스
+ * - JPA Repository: Spring Data JPA 인터페이스
+ * - Repository Adapter: Domain Repository Port 구현체
+ * - Mapper: JPA Entity ↔ Domain Model 변환
+ *
+ * 책임:
+ * - Domain Model → JPA Entity 변환
+ * - JPA Entity → Domain Model 변환
+ * - Domain Repository Port 구현
+ * - 데이터베이스 접근 로직
+ *
+ * 설계 원칙:
+ * - JPA Entity는 도메인 모델과 분리 (별도 클래스)
+ * - 변환 로직을 명확히 구현 (Mapper 사용)
+ * - 도메인 규칙은 도메인 레이어에 위임
+ */
+package com.teambind.springproject.adapter.out.persistence;

--- a/springProject/src/main/java/com/teambind/springproject/adapter/package-info.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Adapter Layer (어댑터 레이어)
+ *
+ * 외부 세계와 애플리케이션을 연결하는 레이어입니다.
+ * Hexagonal Architecture의 Adapter 역할을 수행합니다.
+ *
+ * 구성 요소:
+ * - Inbound Adapter (Primary): 외부 → 애플리케이션 (REST Controller 등)
+ * - Outbound Adapter (Secondary): 애플리케이션 → 외부 (JPA Repository, Kafka Producer 등)
+ *
+ * 책임:
+ * - 외부 요청/응답 형식 변환 (JSON, XML 등)
+ * - Port 구현 (Inbound/Outbound)
+ * - 기술 세부사항 처리 (HTTP, Database, Messaging 등)
+ *
+ * 설계 원칙:
+ * - 도메인 레이어에 의존하지 않음 (Application Port에만 의존)
+ * - 변경 가능성이 높은 기술 스택 격리
+ * - Plug & Play 가능한 구조
+ */
+package com.teambind.springproject.adapter;

--- a/springProject/src/main/java/com/teambind/springproject/application/package-info.java
+++ b/springProject/src/main/java/com/teambind/springproject/application/package-info.java
@@ -1,0 +1,24 @@
+/**
+ * Application Layer (애플리케이션 레이어)
+ *
+ * Use Case를 구현하고 도메인 객체들을 조율하는 레이어입니다.
+ * 트랜잭션 경계를 정의하고, 도메인 로직을 호출합니다.
+ *
+ * 구성 요소:
+ * - Inbound Port: Use Case 인터페이스 (Primary Port)
+ * - Outbound Port: Infrastructure 추상화 인터페이스 (Secondary Port)
+ * - Application Service: Use Case 구현체
+ * - DTO: 외부 레이어와 데이터 교환용 객체
+ *
+ * 책임:
+ * - Use Case 흐름 제어
+ * - 트랜잭션 관리 (@Transactional)
+ * - 도메인 객체 간 조율 (Orchestration)
+ * - DTO ↔ Domain 변환
+ *
+ * 설계 원칙:
+ * - 얇은 레이어로 유지 (Thin Layer)
+ * - 비즈니스 로직은 도메인 레이어에 위임
+ * - Infrastructure 세부사항을 알지 못함 (Port를 통해 추상화)
+ */
+package com.teambind.springproject.application;

--- a/springProject/src/main/java/com/teambind/springproject/application/port/in/package-info.java
+++ b/springProject/src/main/java/com/teambind/springproject/application/port/in/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * Inbound Ports (Primary Ports)
+ *
+ * 외부에서 애플리케이션으로 들어오는 요청을 정의하는 인터페이스입니다.
+ * Use Case를 표현합니다.
+ *
+ * 설계 원칙:
+ * - 하나의 인터페이스는 하나의 Use Case를 표현
+ * - 명령(Command)과 조회(Query)를 분리 (CQRS 패턴)
+ * - 비즈니스 용어를 사용한 명확한 메서드명
+ */
+package com.teambind.springproject.application.port.in;

--- a/springProject/src/main/java/com/teambind/springproject/application/port/out/package-info.java
+++ b/springProject/src/main/java/com/teambind/springproject/application/port/out/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Outbound Ports (Secondary Ports)
+ *
+ * 애플리케이션에서 외부 Infrastructure로 나가는 요청을 정의하는 인터페이스입니다.
+ * Repository, Event Publisher 등을 추상화합니다.
+ *
+ * 포함 요소:
+ * - Repository Interface (도메인 레이어에 정의된 것을 확장할 수도 있음)
+ * - Event Publisher Interface
+ * - External API Client Interface
+ *
+ * 설계 원칙:
+ * - Infrastructure 세부사항을 숨김
+ * - 도메인 중심 인터페이스 (기술 용어 배제)
+ * - 테스트 가능성 향상 (Mock 객체로 대체 가능)
+ */
+package com.teambind.springproject.application.port.out;

--- a/springProject/src/main/java/com/teambind/springproject/domain/package-info.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Domain Layer (도메인 레이어)
+ *
+ * 비즈니스 로직의 핵심을 담당하는 레이어입니다.
+ * 외부 기술(Framework, Database 등)에 의존하지 않으며, 순수한 Java 코드로 구성됩니다.
+ *
+ * 구성 요소:
+ * - Aggregate Root: 트랜잭션 일관성 경계를 정의하는 엔티티
+ * - Entity: 고유 식별자를 가진 도메인 객체
+ * - Value Object: 불변 객체로, 속성의 조합으로 식별
+ * - Domain Service: 여러 Aggregate에 걸친 비즈니스 로직
+ * - Repository Interface: 영속성 추상화 (Port)
+ *
+ * 설계 원칙:
+ * - 도메인 규칙(Invariants)을 강제합니다
+ * - 불변성(Immutability)을 최대한 활용합니다
+ * - 외부 레이어에 의존하지 않습니다 (Dependency Inversion)
+ */
+package com.teambind.springproject.domain;

--- a/springProject/src/main/java/com/teambind/springproject/domain/pricingpolicy/package-info.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/pricingpolicy/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * PricingPolicy Aggregate (가격 정책 애그리거트)
+ *
+ * 시간대별 예약 가격을 관리하는 Bounded Context입니다.
+ *
+ * 책임:
+ * - 룸별 시간대별 가격 정책 설정
+ * - 요일별, 시간대별 가격 차등 적용
+ * - 시간대 중복 검증
+ *
+ * 도메인 규칙 (Invariants):
+ * - 같은 요일 내에서 시간대가 중복될 수 없음
+ * - 시작 시간은 종료 시간보다 이전이어야 함
+ * - 가격은 0원 이상이어야 함
+ *
+ * 주요 클래스:
+ * - PricingPolicy: Aggregate Root
+ * - TimeSlot: Value Object (시간대)
+ * - DayOfWeek: Enum (요일)
+ */
+package com.teambind.springproject.domain.pricingpolicy;

--- a/springProject/src/main/java/com/teambind/springproject/domain/product/package-info.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/product/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Product Aggregate (추가상품 애그리거트)
+ *
+ * 추가상품 관리 및 재고 관리를 담당하는 Bounded Context입니다.
+ *
+ * 책임:
+ * - 추가상품 등록 및 관리
+ * - 적용 범위 관리 (플레이스/룸/예약별)
+ * - 재고 관리 (가용 수량, 총 수량)
+ *
+ * 도메인 규칙 (Invariants):
+ * - 사용 수량은 총 수량을 초과할 수 없음
+ * - PENDING 또는 CONFIRMED 상태의 예약만 재고 차감
+ * - 가격은 0원 이상이어야 함
+ *
+ * 주요 클래스:
+ * - Product: Aggregate Root
+ * - ProductScope: Value Object (적용 범위)
+ * - ProductAvailabilityService: Domain Service (재고 검증)
+ */
+package com.teambind.springproject.domain.product;

--- a/springProject/src/main/java/com/teambind/springproject/domain/reservationpricing/package-info.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/reservationpricing/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * ReservationPricing Aggregate (예약 가격 애그리거트)
+ *
+ * 예약 시점의 가격 정보를 스냅샷으로 저장하는 Bounded Context입니다.
+ *
+ * 책임:
+ * - 예약 시점의 가격 정보 스냅샷 저장
+ * - 예약 총 가격 계산 (룸 가격 + 추가상품 가격)
+ * - 가격 정책 변경 이력 관리 (형상 관리)
+ *
+ * 도메인 규칙 (Invariants):
+ * - 예약 가격은 생성 후 변경 불가 (Immutable Snapshot)
+ * - 총 가격은 룸 가격 + 모든 추가상품 가격의 합
+ * - 모든 금액은 0원 이상이어야 함
+ *
+ * 주요 클래스:
+ * - ReservationPricing: Aggregate Root
+ * - PricingItem: Entity (가격 항목)
+ */
+package com.teambind.springproject.domain.reservationpricing;

--- a/springProject/src/main/java/com/teambind/springproject/domain/shared/package-info.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/shared/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Shared Kernel (공유 커널)
+ *
+ * 여러 Bounded Context에서 공통으로 사용하는 Value Object 및 공통 개념을 정의합니다.
+ *
+ * 포함 요소:
+ * - Money: 금액을 표현하는 Value Object
+ * - ReservationId: 예약 ID Value Object
+ * - RoomId: 룸 ID Value Object
+ * - PlaceId: 플레이스 ID Value Object
+ *
+ * 설계 원칙:
+ * - 모든 Value Object는 불변(Immutable)입니다
+ * - equals/hashCode를 적절히 구현합니다
+ * - 비즈니스 유효성 검증을 생성자에서 수행합니다
+ */
+package com.teambind.springproject.domain.shared;


### PR DESCRIPTION
## Summary
Issue #5의 두 번째 세부 작업으로 Hexagonal Architecture 패키지 구조를 생성했습니다.

## Changes

### Domain Layer (도메인 레이어)
- **pricingpolicy**: PricingPolicy Aggregate (시간대별 가격 정책)
- **product**: Product Aggregate (추가상품 및 재고 관리)
- **reservationpricing**: ReservationPricing Aggregate (예약 가격 스냅샷)
- **shared**: Shared Kernel (공통 Value Objects)

### Application Layer (애플리케이션 레이어)
- **port/in**: Inbound Ports (Use Case 인터페이스)
- **port/out**: Outbound Ports (Infrastructure 추상화)
- **service**: Application Services (Use Case 구현체)
- **dto**: Data Transfer Objects

### Adapter Layer (어댑터 레이어)
- **in/web**: REST Controllers (Primary Adapter)
- **out/persistence**: JPA Repositories (Secondary Adapter)
- **out/messaging**: Kafka Event Handlers (Secondary Adapter)

### Documentation
- 각 레이어별 package-info.java 작성 (HTML 태그 제거)
- PACKAGE_STRUCTURE.md 생성 (아키텍처 가이드)

## Related Issues
Related to #5

## Test Plan
- [x] Gradle 빌드 성공
- [x] 패키지 구조 검증
- [x] package-info.java 문서화 완료

## Next Steps
- 5-3: DB 스키마 설계 및 Flyway 마이그레이션 작성