### PR TITLE
[TASK] 5-4: Docker Compose 파일 작성 (PostgreSQL, Kafka)

### DIFF
--- a/springProject/.env.example
+++ b/springProject/.env.example
@@ -1,18 +1,16 @@
 # Server Configuration
 SERVER_PORT=8080
 
-# Database Configuration
+# PostgreSQL Configuration
 DATABASE_HOST=localhost
-DATABASE_PORT=3306
-DATABASE_USER_NAME=your_database_user
-DATABASE_PASSWORD=your_database_password
-
-# Redis Configuration
-REDIS_HOST=localhost
-REDIS_PORT=6379
+DATABASE_PORT=5432
+DATABASE_NAME=reservation_pricing_db
+DATABASE_USER_NAME=postgres
+DATABASE_PASSWORD=postgres
 
 # Kafka Configuration
-KAFKA_URL=localhost:29092
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+KAFKA_CONSUMER_GROUP_ID=reservation-pricing-service
 
 # External API Configuration
 # Place Info Service API URL

--- a/springProject/DOCKER_SETUP.md
+++ b/springProject/DOCKER_SETUP.md
@@ -1,0 +1,310 @@
+# Docker Setup Guide
+
+예약 가격 관리 서비스의 로컬 개발 환경 구성 가이드입니다.
+
+---
+
+## 사전 요구사항
+
+- Docker Desktop 설치 (https://www.docker.com/products/docker-desktop/)
+- Docker Compose 설치 (Docker Desktop에 포함)
+
+**버전 확인:**
+```bash
+docker --version
+docker-compose --version
+```
+
+---
+
+## 구성 요소
+
+### 1. PostgreSQL 16
+- **이미지**: `postgres:16-alpine`
+- **포트**: `5432`
+- **데이터베이스**: `reservation_pricing_db`
+- **사용자**: `postgres` / `postgres`
+- **볼륨**: `postgres_data` (데이터 영속화)
+
+### 2. Kafka 3.6
+- **이미지**: `confluentinc/cp-kafka:7.5.0` (Kafka 3.6.x 호환)
+- **포트**: `9092` (외부 접속), `29092` (내부 통신)
+- **Zookeeper**: `confluentinc/cp-zookeeper:7.5.0`
+- **자동 토픽 생성**: 활성화
+
+### 3. Kafka UI (Optional)
+- **이미지**: `provectuslabs/kafka-ui:latest`
+- **포트**: `8090`
+- **URL**: http://localhost:8090
+- **용도**: Kafka 토픽/메시지 모니터링
+
+---
+
+## 빠른 시작
+
+### 1. 컨테이너 시작
+```bash
+cd springProject
+docker-compose up -d
+```
+
+### 2. 상태 확인
+```bash
+# 모든 컨테이너 상태 확인
+docker-compose ps
+
+# 로그 확인
+docker-compose logs -f
+
+# 특정 서비스 로그만 확인
+docker-compose logs -f postgres
+docker-compose logs -f kafka
+```
+
+### 3. 헬스체크 확인
+```bash
+# PostgreSQL 연결 테스트
+docker exec -it reservation-pricing-postgres psql -U postgres -d reservation_pricing_db -c "SELECT version();"
+
+# Kafka 브로커 확인
+docker exec -it reservation-pricing-kafka kafka-broker-api-versions --bootstrap-server localhost:9092
+```
+
+### 4. 컨테이너 중지
+```bash
+# 컨테이너 중지 (데이터 유지)
+docker-compose stop
+
+# 컨테이너 중지 및 삭제 (데이터 유지)
+docker-compose down
+
+# 컨테이너 + 볼륨 삭제 (데이터 삭제)
+docker-compose down -v
+```
+
+---
+
+## PostgreSQL 접속
+
+### psql CLI
+```bash
+docker exec -it reservation-pricing-postgres psql -U postgres -d reservation_pricing_db
+```
+
+### DBeaver / DataGrip
+- **Host**: `localhost`
+- **Port**: `5432`
+- **Database**: `reservation_pricing_db`
+- **Username**: `postgres`
+- **Password**: `postgres`
+
+### Flyway 마이그레이션 확인
+```sql
+-- 마이그레이션 이력 확인
+SELECT * FROM flyway_schema_history;
+
+-- 테이블 목록 확인
+\dt
+
+-- pricing_policies 테이블 확인
+SELECT * FROM pricing_policies;
+```
+
+---
+
+## Kafka 사용
+
+### Kafka UI 접속
+```
+http://localhost:8090
+```
+
+**주요 기능**:
+- 토픽 목록 및 생성
+- 메시지 조회 및 발행
+- 컨슈머 그룹 모니터링
+
+### Kafka CLI (컨테이너 내부)
+
+**토픽 생성**:
+```bash
+docker exec -it reservation-pricing-kafka kafka-topics \
+  --create \
+  --bootstrap-server localhost:9092 \
+  --topic room.created \
+  --partitions 3 \
+  --replication-factor 1
+```
+
+**토픽 목록 조회**:
+```bash
+docker exec -it reservation-pricing-kafka kafka-topics \
+  --list \
+  --bootstrap-server localhost:9092
+```
+
+**메시지 발행 (Producer)**:
+```bash
+docker exec -it reservation-pricing-kafka kafka-console-producer \
+  --bootstrap-server localhost:9092 \
+  --topic room.created
+```
+
+**메시지 수신 (Consumer)**:
+```bash
+docker exec -it reservation-pricing-kafka kafka-console-consumer \
+  --bootstrap-server localhost:9092 \
+  --topic room.created \
+  --from-beginning
+```
+
+---
+
+## 애플리케이션 연동
+
+### application-dev.yaml 설정
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/reservation_pricing_db
+    username: postgres
+    password: postgres
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: reservation-pricing-service
+      auto-offset-reset: earliest
+    producer:
+      acks: all
+```
+
+### 애플리케이션 실행
+```bash
+# Gradle로 실행
+./gradlew bootRun
+
+# 또는 IDE에서 SpringProjectApplication 실행
+```
+
+---
+
+## 문제 해결
+
+### PostgreSQL 연결 실패
+```bash
+# 컨테이너 재시작
+docker-compose restart postgres
+
+# 로그 확인
+docker-compose logs postgres
+
+# 헬스체크 확인
+docker exec -it reservation-pricing-postgres pg_isready -U postgres
+```
+
+### Kafka 연결 실패
+```bash
+# Zookeeper 및 Kafka 재시작
+docker-compose restart zookeeper kafka
+
+# Kafka 브로커 확인
+docker exec -it reservation-pricing-kafka kafka-broker-api-versions --bootstrap-server localhost:9092
+```
+
+### 포트 충돌
+이미 사용 중인 포트가 있다면 `docker-compose.yml`에서 포트 변경:
+```yaml
+ports:
+  - "15432:5432"  # PostgreSQL
+  - "19092:9092"  # Kafka
+  - "18090:8080"  # Kafka UI
+```
+
+### 볼륨 초기화 (데이터 완전 삭제)
+```bash
+# 모든 컨테이너 및 볼륨 삭제
+docker-compose down -v
+
+# 재시작
+docker-compose up -d
+```
+
+---
+
+## 개발 워크플로우
+
+### 1. 초기 설정
+```bash
+# Docker 컨테이너 시작
+docker-compose up -d
+
+# PostgreSQL 헬스체크 대기
+sleep 10
+
+# 애플리케이션 실행 (Flyway 자동 마이그레이션)
+./gradlew bootRun
+```
+
+### 2. 데이터베이스 스키마 변경
+```bash
+# 1. 새 마이그레이션 파일 생성
+# src/main/resources/db/migration/V2__add_new_feature.sql
+
+# 2. 애플리케이션 재시작 (Flyway 자동 실행)
+./gradlew bootRun
+
+# 3. 마이그레이션 확인
+docker exec -it reservation-pricing-postgres psql -U postgres -d reservation_pricing_db -c "SELECT * FROM flyway_schema_history;"
+```
+
+### 3. Kafka 이벤트 테스트
+```bash
+# 1. Kafka UI 접속
+open http://localhost:8090
+
+# 2. 토픽 생성 (room.created)
+# 3. 메시지 발행 (Test Data)
+# 4. 애플리케이션 로그 확인
+```
+
+---
+
+## 운영 환경 고려사항
+
+### PostgreSQL
+- **백업**: 정기적인 pg_dump 백업
+- **복제**: Primary-Replica 구성 검토
+- **연결 풀**: HikariCP 설정 최적화
+
+### Kafka
+- **파티션**: 처리량에 따라 파티션 수 조정
+- **복제**: 운영 환경에서는 replication-factor >= 3
+- **보안**: SASL/SSL 인증 설정
+
+---
+
+## 참고 자료
+
+- [PostgreSQL 16 Documentation](https://www.postgresql.org/docs/16/)
+- [Apache Kafka Documentation](https://kafka.apache.org/documentation/)
+- [Confluent Platform Documentation](https://docs.confluent.io/)
+- [Spring Boot with Docker Compose](https://spring.io/guides/gs/spring-boot-docker/)
+
+---
+
+**Last Updated**: 2025-11-08

--- a/springProject/docker-compose.yml
+++ b/springProject/docker-compose.yml
@@ -1,0 +1,89 @@
+services:
+  # PostgreSQL 16
+  postgres:
+    image: postgres:16-alpine
+    container_name: reservation-pricing-postgres
+    environment:
+      POSTGRES_DB: reservation_pricing_db
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      TZ: Asia/Seoul
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - reservation-pricing-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  # Zookeeper (Kafka 의존성)
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    container_name: reservation-pricing-zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+      TZ: Asia/Seoul
+    ports:
+      - "2181:2181"
+    networks:
+      - reservation-pricing-network
+    restart: unless-stopped
+
+  # Kafka 3.6
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: reservation-pricing-kafka
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://kafka:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT_INTERNAL
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+      TZ: Asia/Seoul
+    ports:
+      - "9092:9092"
+    networks:
+      - reservation-pricing-network
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-broker-api-versions --bootstrap-server localhost:9092"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+
+  # Kafka UI (Optional, for development)
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: reservation-pricing-kafka-ui
+    depends_on:
+      - kafka
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+      TZ: Asia/Seoul
+    ports:
+      - "8090:8080"
+    networks:
+      - reservation-pricing-network
+    restart: unless-stopped
+
+networks:
+  reservation-pricing-network:
+    driver: bridge
+
+volumes:
+  postgres_data:
+    driver: local


### PR DESCRIPTION
## Summary
Issue #5의 네 번째 세부 작업으로 로컬 개발 환경을 위한 Docker Compose 구성을 완료했습니다.

## Changes

### docker-compose.yml
**PostgreSQL 16**
- Image: postgres:16-alpine
- Port: 5432
- Database: reservation_pricing_db
- Volume: postgres_data (데이터 영속화)
- Healthcheck: pg_isready

**Kafka 3.6 (Confluent 7.5.0)**
- Image: confluentinc/cp-kafka:7.5.0
- Port: 9092 (외부), 29092 (내부)
- Auto topic creation: enabled
- Healthcheck: kafka-broker-api-versions

**Zookeeper**
- Image: confluentinc/cp-zookeeper:7.5.0
- Port: 2181

**Kafka UI (Development)**
- Image: provectuslabs/kafka-ui:latest
- Port: 8090
- URL: http://localhost:8090

**Network & Volumes**
- Network: reservation-pricing-network (bridge)
- Volume: postgres_data (local driver)

### DOCKER_SETUP.md
- 빠른 시작 가이드
- PostgreSQL 접속 방법 (psql, DBeaver, DataGrip)
- Kafka 사용법 (Kafka UI, CLI)
- Flyway 마이그레이션 확인 방법
- 문제 해결 가이드
- 개발 워크플로우

### .env.example
- PostgreSQL 설정으로 변경 (기존 MySQL에서)
- Kafka bootstrap-servers 설정
- Redis 설정 제거 (사용하지 않음)

## Related Issues
Related to #5

## Test Plan
- [x] docker-compose config 검증
- [x] YAML 문법 확인
- [ ] docker-compose up 테스트 (로컬 환경에서 수동 테스트 권장)
- [ ] PostgreSQL 연결 테스트
- [ ] Kafka 연결 테스트
- [ ] Flyway 마이그레이션 실행 확인

## Usage
```bash
# 컨테이너 시작
docker-compose up -d

# 상태 확인
docker-compose ps

# PostgreSQL 접속
docker exec -it reservation-pricing-postgres psql -U postgres -d reservation_pricing_db

# Kafka UI 접속
open http://localhost:8090

# 컨테이너 중지
docker-compose down
```

## Next Steps
- 5-5: application.yaml 기본 설정 (DB, Kafka 연결 설정)