### PR TITLE
[TASK] 5-5: application.yaml 기본 설정

### DIFF
--- a/springProject/src/main/resources/application-dev.yaml
+++ b/springProject/src/main/resources/application-dev.yaml
@@ -1,56 +1,84 @@
 spring:
-  kafka:
-    bootstrap-servers: ${KAFKA_URL}
-    producer:
-      retries: 3
-      batch-size: 16384
-      buffer-memory: 33554432
-      key-serializer: org.apache.kafka.common.serialization.StringSerializer
-      value-serializer: org.apache.kafka.common.serialization.StringSerializer
-
-    consumer:
-      group-id: room-operation-consumer-group
-      auto-offset-reset: earliest
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-
-    listener:
-      ack-mode: record
-
-
+  # Database Configuration (PostgreSQL)
   datasource:
-    url: jdbc:mariadb://${DATABASE_HOST}:${DATABASE_PORT}/profiles?serverTimezone=Asia/Seoul&useUnicode=true&characterEncoding=utf8mb4
-    username: ${DATABASE_USER_NAME}
-    password: ${DATABASE_PASSWORD}
+    url: jdbc:postgresql://${DATABASE_HOST:localhost}:${DATABASE_PORT:5432}/${DATABASE_NAME:reservation_pricing_db}
+    username: ${DATABASE_USER_NAME:postgres}
+    password: ${DATABASE_PASSWORD:postgres}
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
 
-
+  # JPA/Hibernate Configuration
   jpa:
-    show-sql: true
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
-      ddl-auto: none
-
-
+      ddl-auto: validate
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
+        implicit-strategy: org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy
+    show-sql: true
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.MariaDBDialect
+        use_sql_comments: true
         jdbc:
           time_zone: Asia/Seoul
           batch_size: 50
         order_inserts: true
         order_updates: true
         batch_versioned_data: true
+    open-in-view: false
 
-  data:
-    redis:
-      repositories:
-        enabled: false
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
+  # Flyway Configuration
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+    baseline-version: 0
+    validate-on-migrate: true
 
-  sql:
-    init:
-      mode: never
+  # Kafka Configuration
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      retries: 3
+      acks: all
+      batch-size: 16384
+      buffer-memory: 33554432
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        enable.idempotence: true
+        max.in.flight.requests.per.connection: 5
+
+    consumer:
+      group-id: ${KAFKA_CONSUMER_GROUP_ID:reservation-pricing-service}
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "*"
+
+    listener:
+      ack-mode: manual
+      concurrency: 3
+
+# Logging Configuration
+logging:
+  level:
+    root: INFO
+    com.teambind.springproject: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+    org.springframework.kafka: INFO
+    org.flywaydb: INFO
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
 
 
 

--- a/springProject/src/test/java/com/teambind/springproject/SpringProjectApplicationTests.java
+++ b/springProject/src/test/java/com/teambind/springproject/SpringProjectApplicationTests.java
@@ -1,13 +1,17 @@
 package com.teambind.springproject;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
+@ImportAutoConfiguration(exclude = {FlywayAutoConfiguration.class, KafkaAutoConfiguration.class})
 class SpringProjectApplicationTests {
-	
+
 	@Test
 	void contextLoads() {
 	}
-	
+
 }

--- a/springProject/src/test/resources/application.properties
+++ b/springProject/src/test/resources/application.properties
@@ -1,17 +1,27 @@
 # Test Database Configuration (H2 in-memory)
-spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
 
 # JPA Configuration
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.open-in-view=false
 
 # Flyway Configuration (disabled for tests)
 spring.flyway.enabled=false
 
-# Kafka Configuration (disabled for tests)
+# Kafka Configuration (embedded or disabled for tests)
 spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.consumer.group-id=test-consumer-group
 spring.kafka.consumer.auto-offset-reset=earliest
+spring.kafka.consumer.enable-auto-commit=false
+
+# Logging Configuration
+logging.level.root=INFO
+logging.level.com.teambind.springproject=DEBUG
+logging.level.org.hibernate.SQL=DEBUG


### PR DESCRIPTION
## Summary
Issue #5의 5번째 작업: Spring Boot application.yaml 기본 설정 완료

## Changes
### 1. application-dev.yaml 전면 수정
- **PostgreSQL 연결 설정**
  - HikariCP 커넥션 풀 설정 (max-pool-size: 10, min-idle: 5)
  - 환경 변수 기반 설정 (DATABASE_HOST, DATABASE_PORT 등)
  
- **JPA/Hibernate 설정**
  - PostgreSQL dialect 사용
  - ddl-auto: validate (Flyway로 스키마 관리)
  - CamelCaseToUnderscoresNamingStrategy 적용
  - open-in-view: false (성능 최적화)
  - Batch insert/update 설정 (batch_size: 50)

- **Flyway 설정**
  - baseline-on-migrate: true (기존 DB 마이그레이션 지원)
  - validate-on-migrate: true (마이그레이션 검증)

- **Kafka 설정**
  - Producer: acks=all, idempotence 활성화
  - Consumer: manual ack mode, earliest offset
  - JsonSerializer/JsonDeserializer 사용

### 2. test/resources/application.properties 업데이트
- H2 in-memory DB를 PostgreSQL 호환 모드로 설정
- Flyway 비활성화 (테스트에서는 JPA ddl-auto: create-drop 사용)
- Kafka 테스트 설정

### 3. SpringProjectApplicationTests 수정
- `@ImportAutoConfiguration(exclude = {FlywayAutoConfiguration.class, KafkaAutoConfiguration.class})` 추가
- 테스트 실행 시 PostgreSQL/Kafka 의존성 제거
- 컨텍스트 로드 테스트 성공

## Test Results
```
BUILD SUCCESSFUL in 8s
4 actionable tasks: 3 executed, 1 up-to-date
```

## Related
- Related to #5
- Depends on PR #26 (Docker Compose 설정)

## Next Steps
- Task 5-6: CheckStyle, SpotBugs, PMD 설정
- Task 5-7: GitHub Actions CI 파이프라인 설정