### PR TITLE
FIX ProductIdTest 수정 - null 허용 케이스 반영

### DIFF
--- a/springProject/src/test/java/com/teambind/springproject/domain/shared/ProductIdTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/domain/shared/ProductIdTest.java
@@ -46,12 +46,14 @@ class ProductIdTest {
   class ValidationTests {
 
     @Test
-    @DisplayName("null 값으로 생성 시 예외 발생")
-    void throwExceptionWhenValueIsNull() {
-      // when & then
-      assertThatThrownBy(() -> ProductId.of(null))
-          .isInstanceOf(IllegalArgumentException.class)
-          .hasMessage("Product ID cannot be null");
+    @DisplayName("null 값으로 생성 가능 (신규 엔티티용)")
+    void createWithNullForNewEntity() {
+      // when
+      final ProductId productId = ProductId.of(null);
+
+      // then
+      assertThat(productId).isNotNull();
+      assertThat(productId.getValue()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## Summary
ProductId가 null을 허용하도록 변경되었으나, 테스트는 여전히 null에서 예외가 발생한다고 기대하여 실패하는 문제 수정

## Changes
- ProductIdTest의 "null 값으로 생성 시 예외 발생" 테스트를 제거
- "null 값으로 생성 가능 (신규 엔티티용)" 테스트로 변경
- ProductId.of(null)이 정상 동작하는지 검증

## Background
- Issue #13에서 ProductId를 null 허용하도록 변경
- Repository 계층에서 신규 엔티티 생성 시 ProductId.of(null) 사용
- Auto-generated ID 지원을 위한 변경

## Test Plan
- [x] ProductIdTest 12개 테스트 모두 통과
- [x] 전체 테스트 통과 확인

Related to #13