### PR TITLE
FEAT Repository Port 및 Domain Service 골격 정의 (Issue #12-1)

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/application/port/out/ReservationPricingRepository.java
+++ b/springProject/src/main/java/com/teambind/springproject/application/port/out/ReservationPricingRepository.java
@@ -1,0 +1,51 @@
+package com.teambind.springproject.application.port.out;
+
+import com.teambind.springproject.domain.shared.PlaceId;
+import com.teambind.springproject.domain.shared.ReservationStatus;
+import com.teambind.springproject.domain.shared.RoomId;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * ReservationPricing Aggregate를 영속화하기 위한 Repository Port.
+ * Hexagonal Architecture의 출력 포트(Output Port)입니다.
+ *
+ * <p>이 인터페이스는 예약 가격 스냅샷을 조회하는 메서드를 정의합니다.
+ * 특히 ProductAvailabilityService에서 재고 가용성 검증을 위해 사용됩니다.
+ */
+public interface ReservationPricingRepository {
+
+  /**
+   * PlaceId와 시간 범위로 예약 가격 스냅샷을 조회합니다.
+   * 특정 플레이스에서 주어진 시간 범위에 겹치는 예약들을 조회합니다.
+   *
+   * @param placeId 플레이스 ID
+   * @param start 시작 시간 (inclusive)
+   * @param end 종료 시간 (exclusive)
+   * @param statuses 조회할 예약 상태 목록
+   * @return 조건에 맞는 예약 가격 스냅샷 목록
+   */
+  // TODO: ReservationPricing 도메인 모델 구현 후 반환 타입 변경 (Issue #15)
+  // List<ReservationPricing> findByPlaceIdAndTimeRange(
+  //     PlaceId placeId,
+  //     LocalDateTime start,
+  //     LocalDateTime end,
+  //     List<ReservationStatus> statuses);
+
+  /**
+   * RoomId와 시간 범위로 예약 가격 스냅샷을 조회합니다.
+   * 특정 룸에서 주어진 시간 범위에 겹치는 예약들을 조회합니다.
+   *
+   * @param roomId 룸 ID
+   * @param start 시작 시간 (inclusive)
+   * @param end 종료 시간 (exclusive)
+   * @param statuses 조회할 예약 상태 목록
+   * @return 조건에 맞는 예약 가격 스냅샷 목록
+   */
+  // TODO: ReservationPricing 도메인 모델 구현 후 반환 타입 변경 (Issue #15)
+  // List<ReservationPricing> findByRoomIdAndTimeRange(
+  //     RoomId roomId,
+  //     LocalDateTime start,
+  //     LocalDateTime end,
+  //     List<ReservationStatus> statuses);
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/product/ProductAvailabilityService.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/product/ProductAvailabilityService.java
@@ -1,0 +1,204 @@
+package com.teambind.springproject.domain.product;
+
+import com.teambind.springproject.application.port.out.ReservationPricingRepository;
+import com.teambind.springproject.domain.shared.PlaceId;
+import com.teambind.springproject.domain.shared.ProductId;
+import com.teambind.springproject.domain.shared.RoomId;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 상품 재고 가용성을 검증하는 Domain Service.
+ *
+ * <p>이 서비스는 Product Aggregate의 복잡한 재고 검증 로직을 담당합니다.
+ * Scope별로 다른 재고 확인 방식을 적용합니다:
+ * <ul>
+ *   <li>PLACE: 플레이스 전체의 시간대별 재고 집계</li>
+ *   <li>ROOM: 특정 룸의 시간대별 재고 집계</li>
+ *   <li>RESERVATION: 단순 총 재고만 확인 (시간 무관)</li>
+ * </ul>
+ *
+ * <p>DDD Domain Service 패턴을 따릅니다:
+ * <ul>
+ *   <li>상태를 갖지 않음 (Stateless)</li>
+ *   <li>여러 Aggregate를 조율하는 로직 포함</li>
+ *   <li>Repository에 의존 가능</li>
+ * </ul>
+ *
+ * @see Product
+ * @see ProductScope
+ */
+public class ProductAvailabilityService {
+
+  /**
+   * 상품이 요청한 시간대와 수량에 대해 가용한지 확인합니다.
+   *
+   * @param product 확인할 상품
+   * @param requestedSlots 요청 시간 슬롯 목록 (PLACE, ROOM Scope에서 필요)
+   * @param requestedQuantity 요청 수량
+   * @param repository 예약 가격 Repository (PLACE, ROOM Scope에서 필요)
+   * @return 가용하면 true, 아니면 false
+   * @throws IllegalArgumentException 수량이 0 이하이거나, Scope에 따라 필수 파라미터가 누락된 경우
+   */
+  public boolean isAvailable(
+      final Product product,
+      final List<LocalDateTime> requestedSlots,
+      final int requestedQuantity,
+      final ReservationPricingRepository repository) {
+
+    validateRequestedQuantity(requestedQuantity);
+
+    return switch (product.getScope()) {
+      case RESERVATION -> checkSimpleStockAvailability(product, requestedQuantity);
+      // TODO: Issue #15 (ReservationPricing 도메인 구현) 완료 후 주석 해제
+      // case PLACE -> checkPlaceScopedAvailability(
+      //     product, requestedSlots, requestedQuantity, repository);
+      // case ROOM -> checkRoomScopedAvailability(
+      //     product, requestedSlots, requestedQuantity, repository);
+      default -> throw new UnsupportedOperationException(
+          "Scope " + product.getScope() + " is not yet implemented. "
+              + "Will be implemented after Issue #15 (ReservationPricing domain model)");
+    };
+  }
+
+  /**
+   * RESERVATION Scope 상품의 재고 가용성을 확인합니다.
+   * 시간과 무관하게 총 재고량만 확인합니다.
+   *
+   * @param product 확인할 상품
+   * @param requestedQuantity 요청 수량
+   * @return 가용하면 true, 아니면 false
+   */
+  private boolean checkSimpleStockAvailability(
+      final Product product,
+      final int requestedQuantity) {
+
+    return requestedQuantity <= product.getTotalQuantity();
+  }
+
+  /**
+   * PLACE Scope 상품의 재고 가용성을 확인합니다.
+   * 플레이스 전체에서 요청 시간대별로 사용 중인 최대 재고를 계산합니다.
+   *
+   * @param product 확인할 상품
+   * @param requestedSlots 요청 시간 슬롯 목록
+   * @param requestedQuantity 요청 수량
+   * @param repository 예약 가격 Repository
+   * @return 가용하면 true, 아니면 false
+   */
+  // TODO: Issue #15 (ReservationPricing 도메인 구현) 완료 후 구현
+  // private boolean checkPlaceScopedAvailability(
+  //     final Product product,
+  //     final List<LocalDateTime> requestedSlots,
+  //     final int requestedQuantity,
+  //     final ReservationPricingRepository repository) {
+  //
+  //   validateTimeSlots(requestedSlots);
+  //   final PlaceId placeId = product.getPlaceId();
+  //   final LocalDateTime start = requestedSlots.get(0);
+  //   final LocalDateTime end = requestedSlots.get(requestedSlots.size() - 1);
+  //
+  //   // PENDING과 CONFIRMED 상태의 예약만 조회
+  //   final List<ReservationPricing> overlappingReservations =
+  //       repository.findByPlaceIdAndTimeRange(
+  //           placeId,
+  //           start,
+  //           end,
+  //           List.of(ReservationStatus.PENDING, ReservationStatus.CONFIRMED));
+  //
+  //   // 각 슬롯별 최대 사용량 계산
+  //   final int maxUsedQuantity = requestedSlots.stream()
+  //       .mapToInt(slot -> calculateUsedAtSlot(overlappingReservations, product.getProductId(), slot))
+  //       .max()
+  //       .orElse(0);
+  //
+  //   return maxUsedQuantity + requestedQuantity <= product.getTotalQuantity();
+  // }
+
+  /**
+   * ROOM Scope 상품의 재고 가용성을 확인합니다.
+   * 특정 룸에서 요청 시간대별로 사용 중인 최대 재고를 계산합니다.
+   *
+   * @param product 확인할 상품
+   * @param requestedSlots 요청 시간 슬롯 목록
+   * @param requestedQuantity 요청 수량
+   * @param repository 예약 가격 Repository
+   * @return 가용하면 true, 아니면 false
+   */
+  // TODO: Issue #15 (ReservationPricing 도메인 구현) 완료 후 구현
+  // private boolean checkRoomScopedAvailability(
+  //     final Product product,
+  //     final List<LocalDateTime> requestedSlots,
+  //     final int requestedQuantity,
+  //     final ReservationPricingRepository repository) {
+  //
+  //   validateTimeSlots(requestedSlots);
+  //   final RoomId roomId = product.getRoomId();
+  //   final LocalDateTime start = requestedSlots.get(0);
+  //   final LocalDateTime end = requestedSlots.get(requestedSlots.size() - 1);
+  //
+  //   // PENDING과 CONFIRMED 상태의 예약만 조회
+  //   final List<ReservationPricing> overlappingReservations =
+  //       repository.findByRoomIdAndTimeRange(
+  //           roomId,
+  //           start,
+  //           end,
+  //           List.of(ReservationStatus.PENDING, ReservationStatus.CONFIRMED));
+  //
+  //   // 각 슬롯별 최대 사용량 계산
+  //   final int maxUsedQuantity = requestedSlots.stream()
+  //       .mapToInt(slot -> calculateUsedAtSlot(overlappingReservations, product.getProductId(), slot))
+  //       .max()
+  //       .orElse(0);
+  //
+  //   return maxUsedQuantity + requestedQuantity <= product.getTotalQuantity();
+  // }
+
+  /**
+   * 특정 시간 슬롯에서 해당 상품이 사용 중인 수량을 계산합니다.
+   *
+   * @param reservations 예약 목록
+   * @param productId 상품 ID
+   * @param slot 확인할 시간 슬롯
+   * @return 사용 중인 수량
+   */
+  // TODO: Issue #15 (ReservationPricing 도메인 구현) 완료 후 구현
+  // private int calculateUsedAtSlot(
+  //     final List<ReservationPricing> reservations,
+  //     final ProductId productId,
+  //     final LocalDateTime slot) {
+  //
+  //   return reservations.stream()
+  //       .filter(reservation -> reservation.getTimeSlots().contains(slot))
+  //       .flatMap(reservation -> reservation.getProductBreakdowns().stream())
+  //       .filter(breakdown -> breakdown.productId().equals(productId))
+  //       .mapToInt(ProductPriceBreakdown::quantity)
+  //       .sum();
+  // }
+
+  /**
+   * 요청 수량이 유효한지 검증합니다.
+   *
+   * @param requestedQuantity 요청 수량
+   * @throws IllegalArgumentException 수량이 0 이하인 경우
+   */
+  private void validateRequestedQuantity(final int requestedQuantity) {
+    if (requestedQuantity <= 0) {
+      throw new IllegalArgumentException(
+          "Requested quantity must be positive: " + requestedQuantity);
+    }
+  }
+
+  /**
+   * 시간 슬롯 목록이 유효한지 검증합니다.
+   *
+   * @param requestedSlots 시간 슬롯 목록
+   * @throws IllegalArgumentException 슬롯이 null이거나 비어있는 경우
+   */
+  // TODO: Issue #15 (ReservationPricing 도메인 구현) 완료 후 주석 해제
+  // private void validateTimeSlots(final List<LocalDateTime> requestedSlots) {
+  //   if (requestedSlots == null || requestedSlots.isEmpty()) {
+  //     throw new IllegalArgumentException("Requested time slots cannot be null or empty");
+  //   }
+  // }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/shared/ReservationStatus.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/shared/ReservationStatus.java
@@ -1,0 +1,25 @@
+package com.teambind.springproject.domain.shared;
+
+/**
+ * 예약 상태를 표현하는 Enum.
+ */
+public enum ReservationStatus {
+
+  /**
+   * 예약 대기 상태.
+   * 예약이 생성되었으나 아직 확정되지 않은 상태입니다.
+   */
+  PENDING,
+
+  /**
+   * 예약 확정 상태.
+   * 예약이 확정되어 실제 이용 예정인 상태입니다.
+   */
+  CONFIRMED,
+
+  /**
+   * 예약 취소 상태.
+   * 예약이 취소되어 재고가 복원된 상태입니다.
+   */
+  CANCELLED
+}


### PR DESCRIPTION
## Summary
- ReservationPricingRepository Port 정의 (주석 처리)
- ProductAvailabilityService Domain Service 골격 생성
- ReservationStatus enum 추가

## 구현 내용
### ReservationStatus
- PENDING, CONFIRMED, CANCELLED 상태 정의
- Javadoc 작성

### ReservationPricingRepository Port
- findByPlaceIdAndTimeRange() 시그니처 정의 (주석)
- findByRoomIdAndTimeRange() 시그니처 정의 (주석)
- Issue #15 (ReservationPricing 도메인) 완료 후 주석 해제 예정

### ProductAvailabilityService
- isAvailable() 메서드 골격
- checkSimpleStockAvailability() 구현 완료
- checkPlaceScopedAvailability() 주석 처리 (Issue #15 의존)
- checkRoomScopedAvailability() 주석 처리 (Issue #15 의존)
- calculateUsedAtSlot() 주석 처리 (Issue #15 의존)

## 설계 결정
### Mock 기반 접근
Issue #12와 Issue #15의 병렬 작업 및 충돌 회피를 위해:
- ReservationPricing 도메인은 생성하지 않음
- Repository 메서드는 주석으로 정의만
- Simple Scope만 완전 구현
- Place/Room Scope는 Issue #15 이후 구현

### DDD Domain Service
- Stateless 서비스
- 여러 Aggregate 조율
- Repository 의존 가능
- Product Aggregate 내부에 넣기에는 너무 복잡한 로직 분리

## 테스트 계획
- 12-3 브랜치: Simple Scope 단위 테스트
- 12-5 브랜치: Place/Room Scope Mock 테스트

Related to #12