### PR TITLE
[68-1] SlotReservedEvent DTO 정의

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/event/SlotReservedEvent.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/event/SlotReservedEvent.java
@@ -1,0 +1,84 @@
+package com.teambind.springproject.adapter.in.messaging.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 슬롯 예약 이벤트.
+ * 예약 서비스에서 슬롯이 예약되었을 때 발행되는 이벤트입니다.
+ * <p>
+ * 이 이벤트를 수신하면 해당 예약에 대한 가격 정보를 Pending 상태로 생성합니다.
+ * placeId는 roomId를 통해 PricingPolicy에서 조회하여 사용합니다.
+ * 추가상품 정보는 예약 확정 시 업데이트됩니다.
+ */
+public final class SlotReservedEvent extends Event {
+
+  private static final String EVENT_TYPE_NAME = "SlotReserved";
+  private static final String DEFAULT_TOPIC = "reservation-reserved";
+
+  private final Long roomId;
+  private final LocalDate slotDate;
+  private final List<LocalTime> startTimes;
+  private final Long reservationId;
+  private final LocalDateTime occurredAt;
+
+  @JsonCreator
+  public SlotReservedEvent(
+      @JsonProperty("topic") final String topic,
+      @JsonProperty("eventType") final String eventType,
+      @JsonProperty("roomId") final Long roomId,
+      @JsonProperty("slotDate") final LocalDate slotDate,
+      @JsonProperty("startTimes") final List<LocalTime> startTimes,
+      @JsonProperty("reservationId") final Long reservationId,
+      @JsonProperty("occurredAt") final LocalDateTime occurredAt) {
+    super(topic != null ? topic : DEFAULT_TOPIC, eventType != null ? eventType : EVENT_TYPE_NAME);
+    this.roomId = roomId;
+    this.slotDate = slotDate;
+    this.startTimes = startTimes != null ? List.copyOf(startTimes) : Collections.emptyList();
+    this.reservationId = reservationId;
+    this.occurredAt = occurredAt;
+  }
+
+  @Override
+  public String getEventTypeName() {
+    return EVENT_TYPE_NAME;
+  }
+
+  public Long getRoomId() {
+    return roomId;
+  }
+
+  public LocalDate getSlotDate() {
+    return slotDate;
+  }
+
+  public List<LocalTime> getStartTimes() {
+    return startTimes;
+  }
+
+  public Long getReservationId() {
+    return reservationId;
+  }
+
+  public LocalDateTime getOccurredAt() {
+    return occurredAt;
+  }
+
+  @Override
+  public String toString() {
+    return "SlotReservedEvent{"
+        + "roomId=" + roomId
+        + ", slotDate=" + slotDate
+        + ", startTimes=" + startTimes
+        + ", reservationId=" + reservationId
+        + ", occurredAt=" + occurredAt
+        + ", topic='" + getTopic() + '\''
+        + ", eventType='" + getEventType() + '\''
+        + '}';
+  }
+}

--- a/springProject/src/test/java/com/teambind/springproject/adapter/in/messaging/event/SlotReservedEventTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/adapter/in/messaging/event/SlotReservedEventTest.java
@@ -1,0 +1,152 @@
+package com.teambind.springproject.adapter.in.messaging.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("SlotReservedEvent 테스트")
+class SlotReservedEventTest {
+
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+  }
+
+  @Test
+  @DisplayName("Event 객체 생성 성공")
+  void createEventSuccess() {
+    // Given
+    Long roomId = 1L;
+    LocalDate slotDate = LocalDate.of(2025, 11, 15);
+    List<LocalTime> startTimes = List.of(
+        LocalTime.of(10, 0),
+        LocalTime.of(11, 0)
+    );
+    Long reservationId = 1000L;
+    LocalDateTime occurredAt = LocalDateTime.now();
+
+    // When
+    SlotReservedEvent event = new SlotReservedEvent(
+        "reservation-reserved",
+        "SlotReserved",
+        roomId,
+        slotDate,
+        startTimes,
+        reservationId,
+        occurredAt
+    );
+
+    // Then
+    assertThat(event.getRoomId()).isEqualTo(roomId);
+    assertThat(event.getSlotDate()).isEqualTo(slotDate);
+    assertThat(event.getStartTimes()).hasSize(2);
+    assertThat(event.getReservationId()).isEqualTo(reservationId);
+    assertThat(event.getOccurredAt()).isEqualTo(occurredAt);
+    assertThat(event.getEventTypeName()).isEqualTo("SlotReserved");
+    assertThat(event.getTopic()).isEqualTo("reservation-reserved");
+  }
+
+  @Test
+  @DisplayName("Jackson 직렬화 성공")
+  void serializeEventSuccess() throws Exception {
+    // Given
+    SlotReservedEvent event = new SlotReservedEvent(
+        "reservation-reserved",
+        "SlotReserved",
+        1L,
+        LocalDate.of(2025, 11, 15),
+        List.of(LocalTime.of(10, 0)),
+        1000L,
+        LocalDateTime.of(2025, 11, 9, 10, 0)
+    );
+
+    // When
+    String json = objectMapper.writeValueAsString(event);
+
+    // Then
+    assertThat(json).isNotNull();
+    assertThat(json).contains("\"roomId\":1");
+    assertThat(json).contains("\"reservationId\":1000");
+    assertThat(json).contains("\"slotDate\":");
+  }
+
+  @Test
+  @DisplayName("Jackson 역직렬화 성공")
+  void deserializeEventSuccess() throws Exception {
+    // Given
+    String json = """
+        {
+          "topic": "reservation-reserved",
+          "eventType": "SlotReserved",
+          "roomId": 1,
+          "slotDate": "2025-11-15",
+          "startTimes": ["10:00:00", "11:00:00"],
+          "reservationId": 1000,
+          "occurredAt": "2025-11-09T10:00:00"
+        }
+        """;
+
+    // When
+    SlotReservedEvent event = objectMapper.readValue(json, SlotReservedEvent.class);
+
+    // Then
+    assertThat(event.getRoomId()).isEqualTo(1L);
+    assertThat(event.getSlotDate()).isEqualTo(LocalDate.of(2025, 11, 15));
+    assertThat(event.getStartTimes()).hasSize(2);
+    assertThat(event.getStartTimes().get(0)).isEqualTo(LocalTime.of(10, 0));
+    assertThat(event.getReservationId()).isEqualTo(1000L);
+    assertThat(event.getOccurredAt()).isEqualTo(LocalDateTime.of(2025, 11, 9, 10, 0));
+  }
+
+  @Test
+  @DisplayName("빈 리스트로 생성 시 빈 불변 리스트 반환")
+  void createEventWithEmptyLists() {
+    // Given & When
+    SlotReservedEvent event = new SlotReservedEvent(
+        "reservation-reserved",
+        "SlotReserved",
+        1L,
+        LocalDate.of(2025, 11, 15),
+        null,
+        1000L,
+        LocalDateTime.now()
+    );
+
+    // Then
+    assertThat(event.getStartTimes()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("toString 메서드 동작 확인")
+  void toStringTest() {
+    // Given
+    SlotReservedEvent event = new SlotReservedEvent(
+        "reservation-reserved",
+        "SlotReserved",
+        1L,
+        LocalDate.of(2025, 11, 15),
+        List.of(LocalTime.of(10, 0)),
+        1000L,
+        LocalDateTime.of(2025, 11, 9, 10, 0)
+    );
+
+    // When
+    String result = event.toString();
+
+    // Then
+    assertThat(result).contains("SlotReservedEvent");
+    assertThat(result).contains("roomId=1");
+    assertThat(result).contains("reservationId=1000");
+  }
+}


### PR DESCRIPTION
## 작업 내용

SlotReservedEvent DTO 클래스 정의 및 테스트 작성

## 변경 사항

### 추가된 파일
- SlotReservedEvent.java - Event DTO 클래스
  - roomId, slotDate, startTimes, reservationId, occurredAt 필드
  - placeId는 roomId로 PricingPolicy 조회 시 추출 예정
  - products는 예약 확정 시 업데이트 예정
- SlotReservedEventTest.java - 단위 테스트

### 주요 구현 사항

**불변 객체 설계:**
- 모든 필드 final
- List.copyOf()로 방어적 복사
- Jackson @JsonCreator 사용

**테스트 커버리지:**
- 객체 생성 테스트
- Jackson 직렬화/역직렬화 테스트
- 빈 리스트 처리 테스트
- toString 테스트

## 테스트

```bash
./gradlew test --tests "*SlotReservedEventTest"
```

결과: BUILD SUCCESSFUL

## 체크리스트

- [x] Event 클래스 생성
- [x] Jackson 직렬화/역직렬화 설정
- [x] 불변 객체 설계
- [x] 단위 테스트 작성
- [x] 모든 테스트 통과

## Related Issue

Related to #68