### PR TITLE
FEAT SlotReservedEventHandler 구현

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/handler/SlotReservedEventHandler.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/handler/SlotReservedEventHandler.java
@@ -1,0 +1,130 @@
+package com.teambind.springproject.adapter.in.messaging.handler;
+
+import com.teambind.springproject.adapter.in.messaging.event.SlotReservedEvent;
+import com.teambind.springproject.application.port.out.PricingPolicyRepository;
+import com.teambind.springproject.application.port.out.ReservationPricingRepository;
+import com.teambind.springproject.domain.pricingpolicy.PricingPolicy;
+import com.teambind.springproject.domain.reservationpricing.ReservationPricing;
+import com.teambind.springproject.domain.reservationpricing.TimeSlotPriceBreakdown;
+import com.teambind.springproject.domain.shared.Money;
+import com.teambind.springproject.domain.shared.ReservationId;
+import com.teambind.springproject.domain.shared.RoomId;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * SlotReservedEvent 핸들러.
+ * 슬롯 예약 이벤트를 수신하여 예약 가격 정보를 Pending 상태로 생성합니다.
+ * 이 시점에는 시간대 가격만 계산하며, 추가상품 정보는 예약 확정 시 업데이트됩니다.
+ */
+@Component
+public class SlotReservedEventHandler implements EventHandler<SlotReservedEvent> {
+
+  private static final Logger logger = LoggerFactory.getLogger(SlotReservedEventHandler.class);
+
+  private final PricingPolicyRepository pricingPolicyRepository;
+  private final ReservationPricingRepository reservationPricingRepository;
+
+  public SlotReservedEventHandler(
+      final PricingPolicyRepository pricingPolicyRepository,
+      final ReservationPricingRepository reservationPricingRepository) {
+    this.pricingPolicyRepository = pricingPolicyRepository;
+    this.reservationPricingRepository = reservationPricingRepository;
+  }
+
+  @Override
+  public void handle(final SlotReservedEvent event) {
+    logger.info("Handling SlotReservedEvent: reservationId={}, roomId={}, slotDate={}, slots={}",
+        event.getReservationId(), event.getRoomId(), event.getSlotDate(),
+        event.getStartTimes().size());
+
+    try {
+      final ReservationId reservationId = ReservationId.of(event.getReservationId());
+
+      // 1. 멱등성 검사: 이미 처리된 예약인지 확인
+      if (reservationPricingRepository.existsById(reservationId)) {
+        logger.info("Reservation already exists, skipping: reservationId={}",
+            event.getReservationId());
+        return;
+      }
+
+      final RoomId roomId = RoomId.of(event.getRoomId());
+
+      // 2. 가격 정책 조회
+      final PricingPolicy pricingPolicy = pricingPolicyRepository.findById(roomId)
+          .orElseThrow(() -> new IllegalArgumentException(
+              "Pricing policy not found for roomId: " + event.getRoomId()));
+
+      // 3. 시간 슬롯 목록 생성 (slotDate + startTimes -> List<LocalDateTime>)
+      final List<LocalDateTime> timeSlots = event.getStartTimes().stream()
+          .map(startTime -> event.getSlotDate().atTime(startTime))
+          .sorted()
+          .collect(Collectors.toList());
+
+      if (timeSlots.isEmpty()) {
+        throw new IllegalArgumentException("Time slots cannot be empty");
+      }
+
+      // 4. 시간대별 가격 계산
+      final TimeSlotPriceBreakdown timeSlotBreakdown = calculateTimeSlotBreakdown(
+          pricingPolicy, timeSlots);
+
+      // 5. 예약 가격 생성 (상품 없이 시간대 가격만 계산)
+      final ReservationPricing reservationPricing = ReservationPricing.calculate(
+          reservationId,
+          roomId,
+          timeSlotBreakdown,
+          Collections.emptyList()  // 상품 정보는 예약 확정 시 업데이트
+      );
+
+      // 6. 저장
+      reservationPricingRepository.save(reservationPricing);
+
+      logger.info("Successfully handled SlotReservedEvent: reservationId={}, totalPrice={}",
+          event.getReservationId(), reservationPricing.getTotalPrice().getAmount());
+
+    } catch (final Exception e) {
+      logger.error("Failed to handle SlotReservedEvent: {}", event, e);
+      throw new RuntimeException("Failed to handle SlotReservedEvent", e);
+    }
+  }
+
+  @Override
+  public String getSupportedEventType() {
+    return "SlotReserved";
+  }
+
+  /**
+   * 시간대별 가격 내역을 계산합니다.
+   *
+   * @param pricingPolicy 가격 정책
+   * @param timeSlots 시간 슬롯 목록 (정렬된 상태)
+   * @return 시간대별 가격 내역
+   */
+  private TimeSlotPriceBreakdown calculateTimeSlotBreakdown(
+      final PricingPolicy pricingPolicy,
+      final List<LocalDateTime> timeSlots) {
+
+    final LocalDateTime start = timeSlots.get(0);
+    final LocalDateTime end = timeSlots.get(timeSlots.size() - 1)
+        .plusMinutes(pricingPolicy.getTimeSlot().getMinutes());
+
+    final PricingPolicy.PriceBreakdown priceBreakdown =
+        pricingPolicy.calculatePriceBreakdown(start, end);
+
+    // PriceBreakdown을 TimeSlotPriceBreakdown으로 변환
+    final Map<LocalDateTime, Money> slotPrices = new HashMap<>();
+    for (final PricingPolicy.SlotPrice slotPrice : priceBreakdown.getSlotPrices()) {
+      slotPrices.put(slotPrice.slotTime(), slotPrice.price());
+    }
+
+    return new TimeSlotPriceBreakdown(slotPrices, pricingPolicy.getTimeSlot());
+  }
+}

--- a/springProject/src/test/java/com/teambind/springproject/adapter/in/messaging/handler/SlotReservedEventHandlerTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/adapter/in/messaging/handler/SlotReservedEventHandlerTest.java
@@ -1,0 +1,255 @@
+package com.teambind.springproject.adapter.in.messaging.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.teambind.springproject.adapter.in.messaging.event.SlotReservedEvent;
+import com.teambind.springproject.application.port.out.PricingPolicyRepository;
+import com.teambind.springproject.application.port.out.ReservationPricingRepository;
+import com.teambind.springproject.domain.pricingpolicy.PricingPolicy;
+import com.teambind.springproject.domain.pricingpolicy.TimeRangePrices;
+import com.teambind.springproject.domain.reservationpricing.ReservationPricing;
+import com.teambind.springproject.domain.shared.Money;
+import com.teambind.springproject.domain.shared.PlaceId;
+import com.teambind.springproject.domain.shared.ReservationId;
+import com.teambind.springproject.domain.shared.RoomId;
+import com.teambind.springproject.domain.shared.TimeSlot;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("SlotReservedEventHandler 테스트")
+@ExtendWith(MockitoExtension.class)
+class SlotReservedEventHandlerTest {
+
+  @Mock
+  private PricingPolicyRepository pricingPolicyRepository;
+
+  @Mock
+  private ReservationPricingRepository reservationPricingRepository;
+
+  private SlotReservedEventHandler handler;
+
+  private PricingPolicy samplePricingPolicy;
+
+  @BeforeEach
+  void setUp() {
+    handler = new SlotReservedEventHandler(
+        pricingPolicyRepository,
+        reservationPricingRepository
+    );
+
+    // 샘플 가격 정책 생성 (30분 단위, 기본 가격 10,000원)
+    samplePricingPolicy = PricingPolicy.create(
+        RoomId.of(1L),
+        PlaceId.of(100L),
+        TimeSlot.HALFHOUR,
+        Money.of(new BigDecimal("10000"))
+    );
+  }
+
+  @Test
+  @DisplayName("이벤트 처리 성공 - 예약 가격 정보 생성")
+  void handleEventSuccess() {
+    // Given
+    final SlotReservedEvent event = new SlotReservedEvent(
+        "reservation-reserved",
+        "SlotReserved",
+        1L,
+        LocalDate.of(2025, 11, 15),
+        List.of(LocalTime.of(10, 0), LocalTime.of(10, 30)),
+        1000L,
+        LocalDateTime.now()
+    );
+
+    when(reservationPricingRepository.existsById(ReservationId.of(1000L)))
+        .thenReturn(false);
+    when(pricingPolicyRepository.findById(RoomId.of(1L)))
+        .thenReturn(Optional.of(samplePricingPolicy));
+
+    // When
+    handler.handle(event);
+
+    // Then
+    final ArgumentCaptor<ReservationPricing> captor =
+        ArgumentCaptor.forClass(ReservationPricing.class);
+    verify(reservationPricingRepository).save(captor.capture());
+
+    final ReservationPricing saved = captor.getValue();
+    assertThat(saved.getReservationId().getValue()).isEqualTo(1000L);
+    assertThat(saved.getRoomId().getValue()).isEqualTo(1L);
+    assertThat(saved.getProductBreakdowns()).isEmpty();
+    assertThat(saved.getTotalPrice().getAmount()).isPositive();
+  }
+
+  @Test
+  @DisplayName("멱등성 검사 - 이미 존재하는 예약은 스킵")
+  void handleEventIdempotency() {
+    // Given
+    final SlotReservedEvent event = new SlotReservedEvent(
+        "reservation-reserved",
+        "SlotReserved",
+        1L,
+        LocalDate.of(2025, 11, 15),
+        List.of(LocalTime.of(10, 0)),
+        1000L,
+        LocalDateTime.now()
+    );
+
+    when(reservationPricingRepository.existsById(ReservationId.of(1000L)))
+        .thenReturn(true);
+
+    // When
+    handler.handle(event);
+
+    // Then
+    verify(reservationPricingRepository, never()).save(any());
+    verify(pricingPolicyRepository, never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("가격 정책이 없는 경우 예외 발생")
+  void handleEventNoPricingPolicy() {
+    // Given
+    final SlotReservedEvent event = new SlotReservedEvent(
+        "reservation-reserved",
+        "SlotReserved",
+        999L,
+        LocalDate.of(2025, 11, 15),
+        List.of(LocalTime.of(10, 0)),
+        1000L,
+        LocalDateTime.now()
+    );
+
+    when(reservationPricingRepository.existsById(ReservationId.of(1000L)))
+        .thenReturn(false);
+    when(pricingPolicyRepository.findById(RoomId.of(999L)))
+        .thenReturn(Optional.empty());
+
+    // When & Then
+    assertThatThrownBy(() -> handler.handle(event))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Failed to handle SlotReservedEvent");
+
+    verify(reservationPricingRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("시간 슬롯이 비어있는 경우 예외 발생")
+  void handleEventEmptyTimeSlots() {
+    // Given
+    final SlotReservedEvent event = new SlotReservedEvent(
+        "reservation-reserved",
+        "SlotReserved",
+        1L,
+        LocalDate.of(2025, 11, 15),
+        List.of(),  // 빈 리스트
+        1000L,
+        LocalDateTime.now()
+    );
+
+    when(reservationPricingRepository.existsById(ReservationId.of(1000L)))
+        .thenReturn(false);
+    when(pricingPolicyRepository.findById(RoomId.of(1L)))
+        .thenReturn(Optional.of(samplePricingPolicy));
+
+    // When & Then
+    assertThatThrownBy(() -> handler.handle(event))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Failed to handle SlotReservedEvent");
+  }
+
+  @Test
+  @DisplayName("여러 시간 슬롯 처리 성공")
+  void handleEventMultipleTimeSlots() {
+    // Given
+    final SlotReservedEvent event = new SlotReservedEvent(
+        "reservation-reserved",
+        "SlotReserved",
+        1L,
+        LocalDate.of(2025, 11, 15),
+        List.of(
+            LocalTime.of(10, 0),
+            LocalTime.of(10, 30),
+            LocalTime.of(11, 0),
+            LocalTime.of(11, 30)
+        ),
+        2000L,
+        LocalDateTime.now()
+    );
+
+    when(reservationPricingRepository.existsById(ReservationId.of(2000L)))
+        .thenReturn(false);
+    when(pricingPolicyRepository.findById(RoomId.of(1L)))
+        .thenReturn(Optional.of(samplePricingPolicy));
+
+    // When
+    handler.handle(event);
+
+    // Then
+    final ArgumentCaptor<ReservationPricing> captor =
+        ArgumentCaptor.forClass(ReservationPricing.class);
+    verify(reservationPricingRepository).save(captor.capture());
+
+    final ReservationPricing saved = captor.getValue();
+    assertThat(saved.getTimeSlotBreakdown().slotPrices()).hasSize(4);
+    assertThat(saved.getTotalPrice().getAmount())
+        .isEqualByComparingTo(new BigDecimal("40000"));  // 4 slots * 10,000원
+  }
+
+  @Test
+  @DisplayName("getSupportedEventType 반환값 확인")
+  void getSupportedEventType() {
+    // When & Then
+    assertThat(handler.getSupportedEventType()).isEqualTo("SlotReserved");
+  }
+
+  @Test
+  @DisplayName("정렬되지 않은 시간 슬롯도 정상 처리")
+  void handleEventUnsortedTimeSlots() {
+    // Given
+    final SlotReservedEvent event = new SlotReservedEvent(
+        "reservation-reserved",
+        "SlotReserved",
+        1L,
+        LocalDate.of(2025, 11, 15),
+        List.of(
+            LocalTime.of(11, 0),  // 순서가 섞여있음
+            LocalTime.of(10, 0),
+            LocalTime.of(10, 30)
+        ),
+        3000L,
+        LocalDateTime.now()
+    );
+
+    when(reservationPricingRepository.existsById(ReservationId.of(3000L)))
+        .thenReturn(false);
+    when(pricingPolicyRepository.findById(RoomId.of(1L)))
+        .thenReturn(Optional.of(samplePricingPolicy));
+
+    // When
+    handler.handle(event);
+
+    // Then
+    final ArgumentCaptor<ReservationPricing> captor =
+        ArgumentCaptor.forClass(ReservationPricing.class);
+    verify(reservationPricingRepository).save(captor.capture());
+
+    final ReservationPricing saved = captor.getValue();
+    assertThat(saved.getTimeSlotBreakdown().slotPrices()).hasSize(3);
+  }
+}


### PR DESCRIPTION
## 개요
SlotReservedEvent를 처리하는 이벤트 핸들러를 구현했습니다.

## 주요 변경사항

### 구현 내용
- SlotReservedEventHandler.java 생성
  - EventHandler 인터페이스 구현
  - 멱등성 검사 로직 추가
  - PricingPolicy를 통한 시간대별 가격 계산
  - ReservationPricing 생성 및 저장

### 핸들러 동작 흐름
1. 멱등성 검사: 이미 처리된 예약인지 확인
2. PricingPolicy 조회: roomId로 가격 정책 조회
3. 시간 슬롯 변환: slotDate + startTimes → List<LocalDateTime>
4. 가격 계산: TimeSlotPriceBreakdown 생성
5. 예약 생성: PENDING 상태로 ReservationPricing 생성 (상품 정보 없음)
6. 저장: Repository에 저장

### 테스트
- SlotReservedEventHandlerTest.java
  - 이벤트 처리 성공 테스트
  - 멱등성 검사 테스트
  - 가격 정책 없음 예외 테스트
  - 빈 시간 슬롯 예외 테스트
  - 여러 시간 슬롯 처리 테스트
  - 정렬되지 않은 시간 슬롯 처리 테스트
  - getSupportedEventType 테스트

## 테스트 결과
```
BUILD SUCCESSFUL in 2s
7 tests passing
```

## 관련 이슈
Closes #68-2

## 체크리스트
- [x] 핸들러 구현 완료
- [x] 멱등성 검사 추가
- [x] 단위 테스트 작성
- [x] 모든 테스트 통과
- [ ] EventConsumer 통합 (다음 단계)