### PR TITLE
FEAT EventConsumer에 SlotReservedEvent 통합

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/consumer/EventConsumer.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/consumer/EventConsumer.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.teambind.springproject.adapter.in.messaging.event.Event;
 import com.teambind.springproject.adapter.in.messaging.event.RoomCreatedEvent;
+import com.teambind.springproject.adapter.in.messaging.event.SlotReservedEvent;
 import com.teambind.springproject.adapter.in.messaging.handler.EventHandler;
 import com.teambind.springproject.common.util.json.JsonUtil;
 import java.util.HashMap;
@@ -27,6 +28,7 @@ public class EventConsumer {
 
   static {
     EVENT_TYPE_MAP.put("RoomCreated", RoomCreatedEvent.class);
+    EVENT_TYPE_MAP.put("SlotReserved", SlotReservedEvent.class);
   }
 
   private final JsonUtil jsonUtil;
@@ -51,6 +53,54 @@ public class EventConsumer {
   @KafkaListener(topics = "room-events", groupId = "${spring.kafka.consumer.group-id}")
   public void consume(final String message, final Acknowledgment acknowledgment) {
     logger.info("Received message from room-events topic: {}", message);
+
+    try {
+      // 1. eventType 추출
+      final JsonNode rootNode = objectMapper.readTree(message);
+      final String eventType = rootNode.get("eventType").asText();
+
+      // 2. eventType에 해당하는 클래스 찾기
+      final Class<? extends Event> eventClass = EVENT_TYPE_MAP.get(eventType);
+      if (eventClass == null) {
+        logger.warn("Unknown eventType: {}", eventType);
+        acknowledgment.acknowledge();
+        return;
+      }
+
+      // 3. JSON을 이벤트 객체로 역직렬화
+      final Event event = jsonUtil.fromJson(message, eventClass);
+
+      // 4. 적절한 핸들러 찾기
+      final EventHandler<Event> handler = findHandler(eventType);
+      if (handler == null) {
+        logger.warn("No handler found for eventType: {}", eventType);
+        acknowledgment.acknowledge();
+        return;
+      }
+
+      // 5. 핸들러로 처리
+      handler.handle(event);
+
+      // 6. 수동 커밋
+      acknowledgment.acknowledge();
+      logger.info("Successfully processed event: {}", eventType);
+
+    } catch (final Exception e) {
+      logger.error("Failed to process message: {}", message, e);
+      // TODO: DLQ(Dead Letter Queue)로 전송 또는 재처리 로직 구현
+      acknowledgment.acknowledge(); // 실패해도 일단 acknowledge (무한 재시도 방지)
+    }
+  }
+
+  /**
+   * reservation-reserved 토픽에서 이벤트를 수신합니다.
+   *
+   * @param message        Kafka 메시지 (JSON)
+   * @param acknowledgment Kafka acknowledgment
+   */
+  @KafkaListener(topics = "reservation-reserved", groupId = "${spring.kafka.consumer.group-id}")
+  public void consumeReservationEvents(final String message, final Acknowledgment acknowledgment) {
+    logger.info("Received message from reservation-reserved topic: {}", message);
 
     try {
       // 1. eventType 추출

--- a/springProject/src/test/java/com/teambind/springproject/adapter/in/messaging/consumer/EventConsumerTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/adapter/in/messaging/consumer/EventConsumerTest.java
@@ -8,8 +8,13 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.teambind.springproject.adapter.in.messaging.event.RoomCreatedEvent;
+import com.teambind.springproject.adapter.in.messaging.event.SlotReservedEvent;
 import com.teambind.springproject.adapter.in.messaging.handler.RoomCreatedEventHandler;
+import com.teambind.springproject.adapter.in.messaging.handler.SlotReservedEventHandler;
 import com.teambind.springproject.common.util.json.JsonUtil;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,6 +32,9 @@ class EventConsumerTest {
 
   @Mock
   private RoomCreatedEventHandler roomCreatedEventHandler;
+
+  @Mock
+  private SlotReservedEventHandler slotReservedEventHandler;
 
   @Mock
   private JsonUtil jsonUtil;
@@ -141,6 +149,121 @@ class EventConsumerTest {
 
       // when
       eventConsumer.consume(message, acknowledgment);
+
+      // then
+      verify(acknowledgment).acknowledge();
+    }
+  }
+
+  @Nested
+  @DisplayName("consumeReservationEvents 테스트")
+  class ConsumeReservationEventsTests {
+
+    @Test
+    @DisplayName("SlotReservedEvent 메시지를 정상적으로 처리한다")
+    void consumeSlotReservedEvent() throws Exception {
+      // given
+      objectMapper = new ObjectMapper();
+      objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+      when(slotReservedEventHandler.getSupportedEventType()).thenReturn("SlotReserved");
+      eventConsumer = new EventConsumer(
+          jsonUtil, objectMapper, List.of(slotReservedEventHandler));
+
+      final String message = """
+          {
+            "topic": "reservation-reserved",
+            "eventType": "SlotReserved",
+            "roomId": 1,
+            "slotDate": "2025-11-15",
+            "startTimes": ["10:00:00", "10:30:00"],
+            "reservationId": 1000,
+            "occurredAt": "2025-11-09T10:00:00"
+          }
+          """;
+
+      final SlotReservedEvent mockEvent = new SlotReservedEvent(
+          "reservation-reserved",
+          "SlotReserved",
+          1L,
+          LocalDate.of(2025, 11, 15),
+          List.of(LocalTime.of(10, 0), LocalTime.of(10, 30)),
+          1000L,
+          LocalDateTime.of(2025, 11, 9, 10, 0)
+      );
+      when(jsonUtil.fromJson(any(String.class), any())).thenReturn(mockEvent);
+
+      // when
+      eventConsumer.consumeReservationEvents(message, acknowledgment);
+
+      // then
+      verify(slotReservedEventHandler).handle(any(SlotReservedEvent.class));
+      verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("알 수 없는 eventType이면 핸들러를 호출하지 않는다")
+    void ignoreUnknownEventType() {
+      // given
+      objectMapper = new ObjectMapper();
+      lenient().when(slotReservedEventHandler.getSupportedEventType()).thenReturn("SlotReserved");
+      eventConsumer = new EventConsumer(
+          jsonUtil, objectMapper, List.of(slotReservedEventHandler));
+
+      final String message = """
+          {
+            "topic": "reservation-reserved",
+            "eventType": "UnknownReservationEvent",
+            "reservationId": 1000
+          }
+          """;
+
+      // when
+      eventConsumer.consumeReservationEvents(message, acknowledgment);
+
+      // then
+      verify(slotReservedEventHandler, never()).handle(any(SlotReservedEvent.class));
+      verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("핸들러 처리 중 예외가 발생해도 acknowledge한다")
+    void acknowledgeEvenWhenHandlerFails() throws Exception {
+      // given
+      objectMapper = new ObjectMapper();
+      objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+      when(slotReservedEventHandler.getSupportedEventType()).thenReturn("SlotReserved");
+      eventConsumer = new EventConsumer(
+          jsonUtil, objectMapper, List.of(slotReservedEventHandler));
+
+      final String message = """
+          {
+            "topic": "reservation-reserved",
+            "eventType": "SlotReserved",
+            "roomId": 1,
+            "slotDate": "2025-11-15",
+            "startTimes": ["10:00:00"],
+            "reservationId": 1000,
+            "occurredAt": "2025-11-09T10:00:00"
+          }
+          """;
+
+      final SlotReservedEvent mockEvent = new SlotReservedEvent(
+          "reservation-reserved",
+          "SlotReserved",
+          1L,
+          LocalDate.of(2025, 11, 15),
+          List.of(LocalTime.of(10, 0)),
+          1000L,
+          LocalDateTime.of(2025, 11, 9, 10, 0)
+      );
+      when(jsonUtil.fromJson(any(String.class), any())).thenReturn(mockEvent);
+
+      // Mock handler to throw exception
+      org.mockito.Mockito.doThrow(new RuntimeException("Handler error"))
+          .when(slotReservedEventHandler).handle(any(SlotReservedEvent.class));
+
+      // when
+      eventConsumer.consumeReservationEvents(message, acknowledgment);
 
       // then
       verify(acknowledgment).acknowledge();


### PR DESCRIPTION
## 개요
EventConsumer에 SlotReservedEvent 처리 기능을 통합했습니다.

## 주요 변경사항

### EventConsumer.java
- SlotReservedEvent를 EVENT_TYPE_MAP에 등록
- consumeReservationEvents() 메서드 추가
  - @KafkaListener로 "reservation-reserved" 토픽 구독
  - 기존 consume() 메서드와 동일한 처리 로직
  - eventType 추출 → 역직렬화 → 핸들러 찾기 → 처리 → acknowledge

### EventConsumerTest.java
- consumeReservationEvents 테스트 추가
  - SlotReservedEvent 정상 처리 테스트
  - 알 수 없는 eventType 무시 테스트
  - 예외 발생 시 acknowledge 테스트

## 처리 흐름
1. Kafka에서 "reservation-reserved" 토픽 메시지 수신
2. JSON에서 eventType="SlotReserved" 추출
3. SlotReservedEvent로 역직렬화
4. SlotReservedEventHandler 찾아서 처리
5. 수동 커밋 (acknowledge)

## 테스트 결과
```
BUILD SUCCESSFUL in 1s
All EventConsumer tests passing
```

## 관련 이슈
Closes #68-3

## 체크리스트
- [x] EventConsumer 통합 완료
- [x] Kafka listener 추가
- [x] 단위 테스트 작성
- [x] 모든 테스트 통과
- [ ] 통합 테스트 작성 (다음 단계)