### PR TITLE
[STORY-4] 예약 가격 계산 - 상품 업데이트 기능 (#74)

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/application/dto/request/UpdateProductsRequest.java
+++ b/springProject/src/main/java/com/teambind/springproject/application/dto/request/UpdateProductsRequest.java
@@ -1,0 +1,15 @@
+package com.teambind.springproject.application.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+/**
+ * 예약 상품 업데이트 요청 DTO.
+ */
+public record UpdateProductsRequest(
+    @NotNull(message = "Products list is required")
+    @Valid
+    List<ProductRequest> products
+) {
+}

--- a/springProject/src/main/java/com/teambind/springproject/application/port/in/UpdateReservationProductsUseCase.java
+++ b/springProject/src/main/java/com/teambind/springproject/application/port/in/UpdateReservationProductsUseCase.java
@@ -1,0 +1,24 @@
+package com.teambind.springproject.application.port.in;
+
+import com.teambind.springproject.application.dto.request.UpdateProductsRequest;
+import com.teambind.springproject.application.dto.response.ReservationPricingResponse;
+
+/**
+ * 예약 상품 업데이트 Use Case.
+ * Hexagonal Architecture의 입력 포트(Input Port)입니다.
+ */
+public interface UpdateReservationProductsUseCase {
+
+  /**
+   * 예약의 상품 목록을 업데이트하고 가격을 재계산합니다.
+   * PENDING 상태의 예약에서만 상품 업데이트가 가능합니다.
+   * 재고를 검증하고, 성공 시 재고 락(Soft Lock)이 발생합니다.
+   *
+   * @param reservationId 예약 ID
+   * @param request 상품 업데이트 요청 (productId, quantity 목록)
+   * @return 업데이트된 예약 정보
+   * @throws IllegalStateException PENDING 상태가 아닌 경우
+   * @throws IllegalArgumentException 재고 부족 시
+   */
+  ReservationPricingResponse updateProducts(Long reservationId, UpdateProductsRequest request);
+}

--- a/springProject/src/test/java/com/teambind/springproject/adapter/in/web/reservationpricing/ReservationPricingControllerTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/adapter/in/web/reservationpricing/ReservationPricingControllerTest.java
@@ -11,9 +11,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.teambind.springproject.application.dto.request.CreateReservationRequest;
 import com.teambind.springproject.application.dto.request.ProductRequest;
+import com.teambind.springproject.application.dto.request.UpdateProductsRequest;
 import com.teambind.springproject.application.dto.response.ReservationPricingResponse;
 import com.teambind.springproject.application.port.in.CalculateReservationPriceUseCase;
 import com.teambind.springproject.application.port.in.CreateReservationUseCase;
+import com.teambind.springproject.application.port.in.UpdateReservationProductsUseCase;
+import com.teambind.springproject.domain.reservationpricing.exception.InvalidReservationStatusException;
 import com.teambind.springproject.domain.reservationpricing.exception.ProductNotAvailableException;
 import com.teambind.springproject.domain.reservationpricing.exception.ReservationPricingNotFoundException;
 import com.teambind.springproject.domain.shared.ReservationStatus;
@@ -44,6 +47,9 @@ class ReservationPricingControllerTest {
 
   @MockBean
   private CalculateReservationPriceUseCase calculateReservationPriceUseCase;
+
+  @MockBean
+  private UpdateReservationProductsUseCase updateReservationProductsUseCase;
 
   @Nested
   @DisplayName("POST /api/reservations/pricing - 예약 생성")
@@ -151,7 +157,7 @@ class ReservationPricingControllerTest {
           .thenReturn(response);
 
       // when & then
-      mockMvc.perform(put("/api/reservations/pricing/{reservationId}/confirm", reservationId))
+      mockMvc.perform(put("/api/reservations/{reservationId}/confirm", reservationId))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.reservationId").value(1))
           .andExpect(jsonPath("$.status").value("CONFIRMED"));
@@ -167,7 +173,7 @@ class ReservationPricingControllerTest {
           .thenThrow(new ReservationPricingNotFoundException(reservationId));
 
       // when & then
-      mockMvc.perform(put("/api/reservations/pricing/{reservationId}/confirm", reservationId))
+      mockMvc.perform(put("/api/reservations/{reservationId}/confirm", reservationId))
           .andExpect(status().isNotFound())
           .andExpect(jsonPath("$.code").value("RESERVATION_001"))
           .andExpect(jsonPath("$.exceptionType").value("ReservationPricingNotFoundException"));
@@ -175,7 +181,7 @@ class ReservationPricingControllerTest {
   }
 
   @Nested
-  @DisplayName("PUT /api/reservations/pricing/{reservationId}/cancel - 예약 취소")
+  @DisplayName("PUT /api/reservations/{reservationId}/cancel - 예약 취소")
   class CancelReservationTests {
 
     @Test
@@ -195,7 +201,7 @@ class ReservationPricingControllerTest {
           .thenReturn(response);
 
       // when & then
-      mockMvc.perform(put("/api/reservations/pricing/{reservationId}/cancel", reservationId))
+      mockMvc.perform(put("/api/reservations/{reservationId}/cancel", reservationId))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.reservationId").value(1))
           .andExpect(jsonPath("$.status").value("CANCELLED"));
@@ -211,10 +217,139 @@ class ReservationPricingControllerTest {
           .thenThrow(new ReservationPricingNotFoundException(reservationId));
 
       // when & then
-      mockMvc.perform(put("/api/reservations/pricing/{reservationId}/cancel", reservationId))
+      mockMvc.perform(put("/api/reservations/{reservationId}/cancel", reservationId))
           .andExpect(status().isNotFound())
           .andExpect(jsonPath("$.code").value("RESERVATION_001"))
           .andExpect(jsonPath("$.exceptionType").value("ReservationPricingNotFoundException"));
+    }
+  }
+
+  @Nested
+  @DisplayName("PUT /api/reservations/{reservationId}/products - 예약 상품 업데이트")
+  class UpdateProductsTests {
+
+    @Test
+    @DisplayName("PENDING 상태에서 상품 업데이트에 성공한다")
+    void updateProductsSuccess() throws Exception {
+      // given
+      final Long reservationId = 1L;
+      final ProductRequest productRequest1 = new ProductRequest(1L, 3);
+      final ProductRequest productRequest2 = new ProductRequest(2L, 1);
+
+      final UpdateProductsRequest request = new UpdateProductsRequest(
+          List.of(productRequest1, productRequest2)
+      );
+
+      final ReservationPricingResponse response = new ReservationPricingResponse(
+          reservationId,
+          1L,
+          ReservationStatus.PENDING,
+          BigDecimal.valueOf(30000),
+          LocalDateTime.now()
+      );
+
+      when(updateReservationProductsUseCase.updateProducts(eq(reservationId),
+          any(UpdateProductsRequest.class)))
+          .thenReturn(response);
+
+      // when & then
+      mockMvc.perform(put("/api/reservations/{reservationId}/products", reservationId)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.reservationId").value(1))
+          .andExpect(jsonPath("$.status").value("PENDING"))
+          .andExpect(jsonPath("$.totalPrice").value(30000));
+    }
+
+    @Test
+    @DisplayName("CONFIRMED 상태에서 상품 업데이트 시 400 Bad Request를 반환한다")
+    void updateProductsFailsWhenConfirmed() throws Exception {
+      // given
+      final Long reservationId = 1L;
+      final ProductRequest productRequest = new ProductRequest(1L, 2);
+
+      final UpdateProductsRequest request = new UpdateProductsRequest(
+          List.of(productRequest)
+      );
+
+      when(updateReservationProductsUseCase.updateProducts(eq(reservationId),
+          any(UpdateProductsRequest.class)))
+          .thenThrow(new InvalidReservationStatusException(ReservationStatus.CONFIRMED, "updateProducts"));
+
+      // when & then
+      mockMvc.perform(put("/api/reservations/{reservationId}/products", reservationId)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.code").value("RESERVATION_003"))
+          .andExpect(jsonPath("$.exceptionType").value("InvalidReservationStatusException"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 예약 업데이트 시 404 Not Found를 반환한다")
+    void updateProductsFailsWhenNotFound() throws Exception {
+      // given
+      final Long reservationId = 999L;
+      final ProductRequest productRequest = new ProductRequest(1L, 2);
+
+      final UpdateProductsRequest request = new UpdateProductsRequest(
+          List.of(productRequest)
+      );
+
+      when(updateReservationProductsUseCase.updateProducts(eq(reservationId),
+          any(UpdateProductsRequest.class)))
+          .thenThrow(new ReservationPricingNotFoundException(reservationId));
+
+      // when & then
+      mockMvc.perform(put("/api/reservations/{reservationId}/products", reservationId)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isNotFound())
+          .andExpect(jsonPath("$.code").value("RESERVATION_001"))
+          .andExpect(jsonPath("$.exceptionType").value("ReservationPricingNotFoundException"));
+    }
+
+    @Test
+    @DisplayName("재고 부족 시 400 Bad Request를 반환한다")
+    void updateProductsFailsWhenProductNotAvailable() throws Exception {
+      // given
+      final Long reservationId = 1L;
+      final ProductRequest productRequest = new ProductRequest(1L, 100);
+
+      final UpdateProductsRequest request = new UpdateProductsRequest(
+          List.of(productRequest)
+      );
+
+      when(updateReservationProductsUseCase.updateProducts(eq(reservationId),
+          any(UpdateProductsRequest.class)))
+          .thenThrow(new ProductNotAvailableException(1L, 100));
+
+      // when & then
+      mockMvc.perform(put("/api/reservations/{reservationId}/products", reservationId)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.code").value("RESERVATION_002"))
+          .andExpect(jsonPath("$.exceptionType").value("ProductNotAvailableException"));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 reservationId 시 400 Bad Request를 반환한다")
+    void updateProductsFailsWhenInvalidReservationId() throws Exception {
+      // given
+      final Long invalidReservationId = -1L;
+      final ProductRequest productRequest = new ProductRequest(1L, 2);
+
+      final UpdateProductsRequest request = new UpdateProductsRequest(
+          List.of(productRequest)
+      );
+
+      // when & then
+      mockMvc.perform(put("/api/reservations/{reservationId}/products", invalidReservationId)
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(request)))
+          .andExpect(status().isBadRequest());
     }
   }
 }


### PR DESCRIPTION
## Summary
결제 전(PENDING) 상태의 예약에서 상품을 추가/변경/삭제하고 가격을 재계산하는 기능을 구현했습니다.

### 주요 변경사항
- **Domain Layer**: `ReservationPricing.updateProducts()` 메서드 추가
  - PENDING 상태에서만 상품 업데이트 허용
  - CONFIRMED/CANCELLED 상태에서는 `InvalidReservationStatusException` 발생
  - 상품 변경 시 총 가격 자동 재계산
  
- **Application Layer**: `UpdateReservationProductsUseCase` 및 Service 구현
  - 예약의 시간대 정보를 추출하여 재고 검증
  - 기존 헬퍼 메서드 재사용으로 코드 중복 최소화
  
- **Adapter Layer**: `PUT /api/reservations/{id}/products` API 엔드포인트 추가
  - Controller 베이스 경로 변경: `/api/reservations/pricing` → `/api/reservations`
  - 기존 엔드포인트 경로도 함께 조정

### API Endpoints
- `POST /api/reservations/pricing` - 예약 생성
- `PUT /api/reservations/{id}/confirm` - 예약 확정
- `PUT /api/reservations/{id}/cancel` - 예약 취소
- `PUT /api/reservations/{id}/products` - **상품 업데이트 (NEW)**
- `POST /api/reservations/pricing/preview` - 가격 미리보기

## Test Plan
- [x] Domain 테스트: `ReservationPricingTest` (7개 추가)
  - PENDING 상태에서 상품 업데이트 성공
  - CONFIRMED/CANCELLED 상태에서 업데이트 거부
  - 가격 재계산 검증
  - ReservationId 불변성 검증
  - 빈 리스트로 모든 상품 제거
  
- [x] Controller 테스트: `ReservationPricingControllerTest` (5개 추가)
  - 성공 케이스 (200 OK)
  - 상태 검증 실패 (400 Bad Request)
  - 예약 없음 (404 Not Found)
  - 재고 부족 (400 Bad Request)
  - 유효하지 않은 ID (400 Bad Request)
  
- [x] 전체 테스트 통과 확인

## 기술적 고려사항
- **Hexagonal Architecture** 원칙 준수
- **도메인 주도 설계(DDD)**: 비즈니스 로직을 도메인에 집중
- **불변성 보장**: ReservationId는 상품 변경 후에도 유지
- **상태 머신**: PENDING → CONFIRMED/CANCELLED 전환만 허용
- **재고 관리**: 상품 업데이트 시 실시간 재고 검증

## 관련 이슈
Closes #74

## 체크리스트
- [x] 코드 작성 완료
- [x] 단위 테스트 작성 및 통과
- [x] 통합 테스트 작성 및 통과
- [x] 코드 리뷰 준비 완료