### PR TITLE
FEAT RoomUpdatedEvent 수신 인프라 구축

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/consumer/EventConsumer.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/consumer/EventConsumer.java
@@ -6,6 +6,7 @@ import com.teambind.springproject.adapter.in.messaging.event.Event;
 import com.teambind.springproject.adapter.in.messaging.event.ReservationCancelledEvent;
 import com.teambind.springproject.adapter.in.messaging.event.ReservationConfirmedEvent;
 import com.teambind.springproject.adapter.in.messaging.event.RoomCreatedEvent;
+import com.teambind.springproject.adapter.in.messaging.event.RoomUpdatedEvent;
 import com.teambind.springproject.adapter.in.messaging.event.SlotReservedEvent;
 import com.teambind.springproject.adapter.in.messaging.handler.EventHandler;
 import com.teambind.springproject.common.util.json.JsonUtil;
@@ -30,6 +31,7 @@ public class EventConsumer {
 
   static {
     EVENT_TYPE_MAP.put("RoomCreated", RoomCreatedEvent.class);
+    EVENT_TYPE_MAP.put("RoomUpdated", RoomUpdatedEvent.class);
     EVENT_TYPE_MAP.put("SlotReserved", SlotReservedEvent.class);
     EVENT_TYPE_MAP.put("ReservationConfirmed", ReservationConfirmedEvent.class);
     EVENT_TYPE_MAP.put("ReservationCancelled", ReservationCancelledEvent.class);
@@ -49,14 +51,14 @@ public class EventConsumer {
   }
 
   /**
-   * room-events 토픽에서 이벤트를 수신합니다.
+   * room-created, room-updated 토픽에서 이벤트를 수신합니다.
    *
    * @param message        Kafka 메시지 (JSON)
    * @param acknowledgment Kafka acknowledgment
    */
-  @KafkaListener(topics = "room-events", groupId = "${spring.kafka.consumer.group-id}")
+  @KafkaListener(topics = {"room-created", "room-updated"}, groupId = "${spring.kafka.consumer.group-id}")
   public void consume(final String message, final Acknowledgment acknowledgment) {
-    logger.info("Received message from room-events topic: {}", message);
+    logger.info("Received message from room topics: {}", message);
 
     try {
       // 1. eventType 추출

--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/event/RoomUpdatedEvent.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/event/RoomUpdatedEvent.java
@@ -1,0 +1,60 @@
+package com.teambind.springproject.adapter.in.messaging.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 룸 업데이트 이벤트.
+ * Place 서비스에서 룸이 업데이트되었을 때 발행되는 이벤트입니다.
+ * <p>
+ * 이 이벤트를 수신하면 해당 룸에 대한 가격 정책을 업데이트합니다.
+ */
+public final class RoomUpdatedEvent extends Event {
+
+  private static final String EVENT_TYPE_NAME = "RoomUpdated";
+
+  private final Long placeId;
+  private final Long roomId;
+  private final String timeSlot;
+
+  @JsonCreator
+  public RoomUpdatedEvent(
+      @JsonProperty("topic") final String topic,
+      @JsonProperty("eventType") final String eventType,
+      @JsonProperty("placeId") final Long placeId,
+      @JsonProperty("roomId") final Long roomId,
+      @JsonProperty("timeSlot") final String timeSlot) {
+    super(topic, eventType);
+    this.placeId = placeId;
+    this.roomId = roomId;
+    this.timeSlot = timeSlot;
+  }
+
+  @Override
+  public String getEventTypeName() {
+    return EVENT_TYPE_NAME;
+  }
+
+  public Long getPlaceId() {
+    return placeId;
+  }
+
+  public Long getRoomId() {
+    return roomId;
+  }
+
+  public String getTimeSlot() {
+    return timeSlot;
+  }
+
+  @Override
+  public String toString() {
+    return "RoomUpdatedEvent{"
+        + "placeId=" + placeId
+        + ", roomId=" + roomId
+        + ", timeSlot='" + timeSlot + '\''
+        + ", topic='" + getTopic() + '\''
+        + ", eventType='" + getEventType() + '\''
+        + '}';
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/handler/RoomUpdatedEventHandler.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/handler/RoomUpdatedEventHandler.java
@@ -1,0 +1,32 @@
+package com.teambind.springproject.adapter.in.messaging.handler;
+
+import com.teambind.springproject.adapter.in.messaging.event.RoomUpdatedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * RoomUpdatedEvent 핸들러.
+ * 룸 업데이트 이벤트를 수신하여 로깅합니다.
+ * TODO: 가격 정책 TimeSlot 업데이트 기능은 별도 이슈로 분리하여 구현 예정
+ */
+@Component
+public class RoomUpdatedEventHandler implements EventHandler<RoomUpdatedEvent> {
+
+  private static final Logger logger = LoggerFactory.getLogger(RoomUpdatedEventHandler.class);
+
+  @Override
+  public void handle(final RoomUpdatedEvent event) {
+    logger.info("Received RoomUpdatedEvent: roomId={}, placeId={}, timeSlot={}",
+        event.getRoomId(), event.getPlaceId(), event.getTimeSlot());
+
+    // 현재는 이벤트 수신 및 로깅만 수행
+    // 향후 가격 정책 TimeSlot 업데이트 로직 추가 필요
+    logger.info("RoomUpdatedEvent logged successfully");
+  }
+
+  @Override
+  public String getSupportedEventType() {
+    return "RoomUpdated";
+  }
+}


### PR DESCRIPTION
## Summary
Room 업데이트 이벤트를 수신하는 인프라를 구축했습니다.
현재는 이벤트 수신 및 로깅만 수행하며, 실제 가격 정책 업데이트 로직은 후속 작업으로 진행합니다.

## Changes
### 1. RoomUpdatedEvent 클래스 추가
- placeId, roomId, timeSlot 정보 포함
- Place 서비스에서 룸 업데이트 시 발행되는 이벤트

### 2. RoomUpdatedEventHandler 추가
- 이벤트 수신 및 로깅
- TODO: TimeSlot 업데이트 로직 구현 예정

### 3. EventConsumer 업데이트
- RoomUpdatedEvent 타입 등록
- room-created, room-updated 토픽 구독

## Test Plan
- [x] 빌드 성공 확인
- [x] 이벤트 타입 등록 확인
- [ ] 향후: TimeSlot 업데이트 로직 구현 후 통합 테스트

## 후속 작업
별도 CR 및 Task 이슈로 진행 예정:
- PricingPolicy TimeSlot 변경 가능하도록 도메인 수정
- RoomUpdatedEventHandler 업데이트 로직 구현