### PR TITLE
FEAT RoomUpdatedEventHandler TimeSlot 업데이트 로직 구현

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/handler/RoomUpdatedEventHandler.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/handler/RoomUpdatedEventHandler.java
@@ -1,28 +1,48 @@
 package com.teambind.springproject.adapter.in.messaging.handler;
 
 import com.teambind.springproject.adapter.in.messaging.event.RoomUpdatedEvent;
+import com.teambind.springproject.application.port.in.UpdatePricingPolicyUseCase;
+import com.teambind.springproject.domain.pricingpolicy.exception.PricingPolicyNotFoundException;
+import com.teambind.springproject.domain.shared.RoomId;
+import com.teambind.springproject.domain.shared.TimeSlot;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /**
  * RoomUpdatedEvent 핸들러.
- * 룸 업데이트 이벤트를 수신하여 로깅합니다.
- * TODO: 가격 정책 TimeSlot 업데이트 기능은 별도 이슈로 분리하여 구현 예정
+ * 룸 업데이트 이벤트를 수신하여 가격 정책의 TimeSlot을 업데이트합니다.
  */
 @Component
 public class RoomUpdatedEventHandler implements EventHandler<RoomUpdatedEvent> {
 
   private static final Logger logger = LoggerFactory.getLogger(RoomUpdatedEventHandler.class);
 
+  private final UpdatePricingPolicyUseCase updatePricingPolicyUseCase;
+
+  public RoomUpdatedEventHandler(final UpdatePricingPolicyUseCase updatePricingPolicyUseCase) {
+    this.updatePricingPolicyUseCase = updatePricingPolicyUseCase;
+  }
+
   @Override
   public void handle(final RoomUpdatedEvent event) {
-    logger.info("Received RoomUpdatedEvent: roomId={}, placeId={}, timeSlot={}",
+    logger.info("Handling RoomUpdatedEvent: roomId={}, placeId={}, timeSlot={}",
         event.getRoomId(), event.getPlaceId(), event.getTimeSlot());
 
-    // 현재는 이벤트 수신 및 로깅만 수행
-    // 향후 가격 정책 TimeSlot 업데이트 로직 추가 필요
-    logger.info("RoomUpdatedEvent logged successfully");
+    try {
+      final RoomId roomId = RoomId.of(event.getRoomId());
+      final TimeSlot newTimeSlot = TimeSlot.valueOf(event.getTimeSlot());
+
+      updatePricingPolicyUseCase.updateTimeSlot(roomId, newTimeSlot);
+
+      logger.info("Successfully updated TimeSlot for roomId={}", event.getRoomId());
+    } catch (final PricingPolicyNotFoundException e) {
+      logger.warn("PricingPolicy not found for roomId={}, skipping TimeSlot update",
+          event.getRoomId());
+    } catch (final Exception e) {
+      logger.error("Failed to handle RoomUpdatedEvent: {}", event, e);
+      throw new RuntimeException("Failed to handle RoomUpdatedEvent", e);
+    }
   }
 
   @Override


### PR DESCRIPTION
## Summary
RoomUpdatedEventHandler에 실제 TimeSlot 업데이트 로직을 구현했습니다.

## Changes
- UpdatePricingPolicyUseCase 의존성 주입
- handle 메서드에서 updateTimeSlot 호출
- PricingPolicyNotFoundException 처리 (WARN 로깅 후 skip)
- 일반 예외는 RuntimeException으로 래핑

## Flow
```
RoomUpdatedEvent 수신
→ RoomId, TimeSlot 파싱
→ UpdatePricingPolicyUseCase.updateTimeSlot 호출
→ PricingPolicy.updateTimeSlot (도메인)
→ 저장
```

## Test Plan
- [x] 빌드 성공 확인
- [ ] 향후: E2E 테스트 (Place 서비스 연동)

Closes #99
Relates to #96