### PR TITLE
FIX GlobalExceptionHandler IllegalArgumentException 및 IllegalStateException 핸들러 추가

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/common/exceptions/ErrorResponse.java
+++ b/springProject/src/main/java/com/teambind/springproject/common/exceptions/ErrorResponse.java
@@ -24,6 +24,7 @@ public class ErrorResponse {
 	private String path;
 	private String exceptionType;
 
+	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	@Builder.Default
 	private List<FieldErrorDetail> fieldErrors = new ArrayList<>();
 

--- a/springProject/src/main/java/com/teambind/springproject/common/exceptions/GlobalExceptionHandler.java
+++ b/springProject/src/main/java/com/teambind/springproject/common/exceptions/GlobalExceptionHandler.java
@@ -85,8 +85,39 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		return ResponseEntity.badRequest().body(errorResponse);
 	}
 
+	/**
+	 * IllegalArgumentException 처리 (도메인 validation 실패)
+	 */
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ErrorResponse> handleIllegalArgumentException(
+			IllegalArgumentException ex, HttpServletRequest request) {
+		log.warn("Invalid argument: {}", ex.getMessage());
 
+		ErrorResponse errorResponse = ErrorResponse.of(
+				HttpStatus.BAD_REQUEST.value(),
+				"INVALID_ARGUMENT",
+				ex.getMessage(),
+				request.getRequestURI()
+		);
+		return ResponseEntity.badRequest().body(errorResponse);
+	}
 
+	/**
+	 * IllegalStateException 처리 (도메인 상태 위반)
+	 */
+	@ExceptionHandler(IllegalStateException.class)
+	public ResponseEntity<ErrorResponse> handleIllegalStateException(
+			IllegalStateException ex, HttpServletRequest request) {
+		log.warn("Invalid state: {}", ex.getMessage());
+
+		ErrorResponse errorResponse = ErrorResponse.of(
+				HttpStatus.CONFLICT.value(),
+				"INVALID_STATE",
+				ex.getMessage(),
+				request.getRequestURI()
+		);
+		return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
+	}
 
 	/**
 	 * Validation 예외 처리 (필드 에러 상세 정보 포함)

--- a/springProject/src/test/java/com/teambind/springproject/common/exceptions/GlobalExceptionHandlerTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/common/exceptions/GlobalExceptionHandlerTest.java
@@ -1,0 +1,131 @@
+package com.teambind.springproject.common.exceptions;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.teambind.springproject.adapter.in.web.pricingpolicy.PricingPolicyController;
+import com.teambind.springproject.application.port.in.CopyPricingPolicyUseCase;
+import com.teambind.springproject.application.port.in.GetPricingPolicyUseCase;
+import com.teambind.springproject.application.port.in.UpdatePricingPolicyUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(PricingPolicyController.class)
+@DisplayName("GlobalExceptionHandler 통합 테스트")
+class GlobalExceptionHandlerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private GetPricingPolicyUseCase getPricingPolicyUseCase;
+
+  @MockBean
+  private UpdatePricingPolicyUseCase updatePricingPolicyUseCase;
+
+  @MockBean
+  private CopyPricingPolicyUseCase copyPricingPolicyUseCase;
+
+  @Nested
+  @DisplayName("IllegalArgumentException 처리")
+  class IllegalArgumentExceptionHandling {
+
+    @Test
+    @DisplayName("IllegalArgumentException 발생 시 400 Bad Request 응답")
+    void shouldReturn400WhenIllegalArgumentException() throws Exception {
+      // given
+      when(getPricingPolicyUseCase.getPolicy(any()))
+          .thenThrow(new IllegalArgumentException("Room ID cannot be null"));
+
+      // when & then
+      mockMvc.perform(get("/api/pricing-policies/1"))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.status").value(400))
+          .andExpect(jsonPath("$.code").value("INVALID_ARGUMENT"))
+          .andExpect(jsonPath("$.message").value("Room ID cannot be null"))
+          .andExpect(jsonPath("$.path").value("/api/pricing-policies/1"))
+          .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    @Test
+    @DisplayName("Domain validation 실패 시 적절한 에러 메시지 반환")
+    void shouldReturnProperErrorMessageForDomainValidationFailure() throws Exception {
+      // given
+      String errorMessage = "Default price cannot be null";
+      when(getPricingPolicyUseCase.getPolicy(any()))
+          .thenThrow(new IllegalArgumentException(errorMessage));
+
+      // when & then
+      mockMvc.perform(get("/api/pricing-policies/123"))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.code").value("INVALID_ARGUMENT"))
+          .andExpect(jsonPath("$.message").value(errorMessage));
+    }
+  }
+
+  @Nested
+  @DisplayName("IllegalStateException 처리")
+  class IllegalStateExceptionHandling {
+
+    @Test
+    @DisplayName("IllegalStateException 발생 시 409 Conflict 응답")
+    void shouldReturn409WhenIllegalStateException() throws Exception {
+      // given
+      when(getPricingPolicyUseCase.getPolicy(any()))
+          .thenThrow(new IllegalStateException("Cannot modify confirmed pricing policy"));
+
+      // when & then
+      mockMvc.perform(get("/api/pricing-policies/1"))
+          .andExpect(status().isConflict())
+          .andExpect(jsonPath("$.status").value(409))
+          .andExpect(jsonPath("$.code").value("INVALID_STATE"))
+          .andExpect(jsonPath("$.message").value("Cannot modify confirmed pricing policy"))
+          .andExpect(jsonPath("$.path").value("/api/pricing-policies/1"))
+          .andExpect(jsonPath("$.timestamp").exists());
+    }
+  }
+
+  @Nested
+  @DisplayName("ErrorResponse 구조 검증")
+  class ErrorResponseStructure {
+
+    @Test
+    @DisplayName("ErrorResponse는 표준 필드를 모두 포함해야 함")
+    void errorResponseShouldContainAllStandardFields() throws Exception {
+      // given
+      when(getPricingPolicyUseCase.getPolicy(any()))
+          .thenThrow(new IllegalArgumentException("Test error"));
+
+      // when & then
+      mockMvc.perform(get("/api/pricing-policies/999"))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.timestamp").exists())
+          .andExpect(jsonPath("$.status").exists())
+          .andExpect(jsonPath("$.code").exists())
+          .andExpect(jsonPath("$.message").exists())
+          .andExpect(jsonPath("$.path").exists());
+    }
+
+    @Test
+    @DisplayName("ErrorResponse는 fieldErrors를 포함하지 않음 (IllegalArgumentException)")
+    void errorResponseShouldNotContainFieldErrorsForIllegalArgument() throws Exception {
+      // given
+      when(getPricingPolicyUseCase.getPolicy(any()))
+          .thenThrow(new IllegalArgumentException("Invalid input"));
+
+      // when & then
+      mockMvc.perform(get("/api/pricing-policies/1"))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.fieldErrors").doesNotExist());
+    }
+  }
+}


### PR DESCRIPTION
## Summary

도메인 validation 실패 시 500 Internal Server Error 대신 적절한 HTTP 상태 코드를 반환하도록 GlobalExceptionHandler에 예외 핸들러를 추가했습니다.

### Changes

- `IllegalArgumentException` 핸들러 추가 → 400 Bad Request 응답
- `IllegalStateException` 핸들러 추가 → 409 Conflict 응답  
- `ErrorResponse.fieldErrors`에 `@JsonInclude(NON_EMPTY)` 추가하여 빈 배열 제외
- 통합 테스트 추가 (5개 테스트, 모두 통과)

### Test Coverage

**GlobalExceptionHandlerTest** (5 tests):
- IllegalArgumentException → 400 응답 검증
- IllegalStateException → 409 응답 검증
- ErrorResponse 구조 검증
- fieldErrors 필드 제외 검증

### Before

```json
{
  "status": 500,
  "code": "INTERNAL_SERVER_ERROR",
  "message": "서버 내부 오류가 발생했습니다."
}
```

### After

```json
{
  "status": 400,
  "code": "INVALID_ARGUMENT",
  "message": "Room ID cannot be null",
  "path": "/api/pricing-policies/1",
  "timestamp": "2025-01-15T10:30:00"
}
```

## Test Results

```bash
./gradlew test --tests "GlobalExceptionHandlerTest"
BUILD SUCCESSFUL - 5 tests passed
```

## Impact

- Production 버그 수정: 도메인 validation 실패 시 적절한 HTTP 상태 코드 반환
- API 사용자에게 더 명확한 에러 메시지 제공
- 모니터링 및 디버깅 개선

Closes #115