### PR TITLE
REFACTOR: Improve RESTful API design and add API versioning

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/web/admin/RoomAllowedProductController.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/web/admin/RoomAllowedProductController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 룸별 허용 상품 관리 Admin REST Controller.
  */
 @RestController
-@RequestMapping("/api/admin/rooms/{roomId}/allowed-products")
+@RequestMapping("/api/v1/admin/rooms/{roomId}/allowed-products")
 @Validated
 public class RoomAllowedProductController {
 

--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/web/pricingpolicy/PricingPolicyController.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/web/pricingpolicy/PricingPolicyController.java
@@ -33,7 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 가격 정책 관리 REST Controller.
  */
 @RestController
-@RequestMapping("/api/pricing-policies")
+@RequestMapping("/api/v1/pricing-policies")
 @Validated
 public class PricingPolicyController {
 

--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/web/product/ProductController.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/web/product/ProductController.java
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 추가상품 관리 REST Controller.
  */
 @RestController
-@RequestMapping("/api/products")
+@RequestMapping("/api/v1/products")
 @Validated
 public class ProductController {
 

--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/web/reservationpricing/ReservationPricingController.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/web/reservationpricing/ReservationPricingController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 예약 가격 관리 REST Controller.
  */
 @RestController
-@RequestMapping("/api/reservations")
+@RequestMapping("/api/v1/reservations")
 @Validated
 public class ReservationPricingController {
 
@@ -41,12 +41,12 @@ public class ReservationPricingController {
   }
 
   /**
-   * 예약 가격 계산 및 생성.
+   * 예약 생성 (가격 계산 포함).
    *
    * @param request 예약 생성 요청
    * @return 생성된 예약 정보
    */
-  @PostMapping("/pricing")
+  @PostMapping
   public ResponseEntity<ReservationPricingResponse> createReservation(
       @RequestBody @Valid final CreateReservationRequest request) {
 
@@ -95,7 +95,7 @@ public class ReservationPricingController {
    * @param request 예약 요청 정보
    * @return 가격 미리보기 (시간대 가격 + 상품별 가격 + 총 합계)
    */
-  @PostMapping("/pricing/preview")
+  @PostMapping("/preview")
   public ResponseEntity<PricePreviewResponse> previewPrice(
       @RequestBody @Valid final CreateReservationRequest request) {
 

--- a/springProject/src/test/java/com/teambind/springproject/adapter/in/web/admin/RoomAllowedProductControllerTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/adapter/in/web/admin/RoomAllowedProductControllerTest.java
@@ -69,7 +69,7 @@ class RoomAllowedProductControllerTest {
           .thenReturn(response);
 
       // when & then
-      mockMvc.perform(post("/api/admin/rooms/{roomId}/allowed-products", roomId)
+      mockMvc.perform(post("/api/v1/admin/rooms/{roomId}/allowed-products", roomId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isOk())
@@ -99,7 +99,7 @@ class RoomAllowedProductControllerTest {
           .thenReturn(response);
 
       // when & then
-      mockMvc.perform(post("/api/admin/rooms/{roomId}/allowed-products", roomId)
+      mockMvc.perform(post("/api/v1/admin/rooms/{roomId}/allowed-products", roomId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isOk())
@@ -117,7 +117,7 @@ class RoomAllowedProductControllerTest {
       final SetRoomAllowedProductsRequest request = new SetRoomAllowedProductsRequest(productIds);
 
       // when & then
-      mockMvc.perform(post("/api/admin/rooms/{roomId}/allowed-products", invalidRoomId)
+      mockMvc.perform(post("/api/v1/admin/rooms/{roomId}/allowed-products", invalidRoomId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isBadRequest());
@@ -143,7 +143,7 @@ class RoomAllowedProductControllerTest {
           .thenReturn(response);
 
       // when & then
-      mockMvc.perform(get("/api/admin/rooms/{roomId}/allowed-products", roomId))
+      mockMvc.perform(get("/api/v1/admin/rooms/{roomId}/allowed-products", roomId))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.roomId").value(roomId))
           .andExpect(jsonPath("$.allowedProductIds").isArray())
@@ -167,7 +167,7 @@ class RoomAllowedProductControllerTest {
           .thenReturn(response);
 
       // when & then
-      mockMvc.perform(get("/api/admin/rooms/{roomId}/allowed-products", roomId))
+      mockMvc.perform(get("/api/v1/admin/rooms/{roomId}/allowed-products", roomId))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.roomId").value(roomId))
           .andExpect(jsonPath("$.allowedProductIds").isArray())
@@ -187,7 +187,7 @@ class RoomAllowedProductControllerTest {
       doNothing().when(deleteRoomAllowedProductsUseCase).deleteAllowedProducts(roomId);
 
       // when & then
-      mockMvc.perform(delete("/api/admin/rooms/{roomId}/allowed-products", roomId))
+      mockMvc.perform(delete("/api/v1/admin/rooms/{roomId}/allowed-products", roomId))
           .andExpect(status().isNoContent());
     }
 
@@ -198,7 +198,7 @@ class RoomAllowedProductControllerTest {
       final Long invalidRoomId = 0L;
 
       // when & then
-      mockMvc.perform(delete("/api/admin/rooms/{roomId}/allowed-products", invalidRoomId))
+      mockMvc.perform(delete("/api/v1/admin/rooms/{roomId}/allowed-products", invalidRoomId))
           .andExpect(status().isBadRequest());
     }
   }
@@ -226,7 +226,7 @@ class RoomAllowedProductControllerTest {
           .thenReturn(response);
 
       // when & then
-      mockMvc.perform(post("/api/admin/rooms/{roomId}/allowed-products", roomId)
+      mockMvc.perform(post("/api/v1/admin/rooms/{roomId}/allowed-products", roomId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isOk())
@@ -253,7 +253,7 @@ class RoomAllowedProductControllerTest {
           .thenReturn(response);
 
       // when & then
-      mockMvc.perform(post("/api/admin/rooms/{roomId}/allowed-products", roomId)
+      mockMvc.perform(post("/api/v1/admin/rooms/{roomId}/allowed-products", roomId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isOk())

--- a/springProject/src/test/java/com/teambind/springproject/adapter/in/web/pricingpolicy/PricingPolicyControllerTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/adapter/in/web/pricingpolicy/PricingPolicyControllerTest.java
@@ -78,7 +78,7 @@ class PricingPolicyControllerTest {
       when(getPricingPolicyUseCase.getPolicy(any(RoomId.class))).thenReturn(policy);
 
       // when & then
-      mockMvc.perform(get("/api/pricing-policies/{roomId}", roomId))
+      mockMvc.perform(get("/api/v1/pricing-policies/{roomId}", roomId))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.roomId").value(roomId))
           .andExpect(jsonPath("$.placeId").value(100))
@@ -96,7 +96,7 @@ class PricingPolicyControllerTest {
           .thenThrow(new PricingPolicyNotFoundException("Pricing policy not found"));
 
       // when & then
-      mockMvc.perform(get("/api/pricing-policies/{roomId}", roomId))
+      mockMvc.perform(get("/api/v1/pricing-policies/{roomId}", roomId))
           .andExpect(status().isNotFound())
           .andExpect(jsonPath("$.code").value("PRICING_001"));
     }
@@ -105,7 +105,7 @@ class PricingPolicyControllerTest {
     @DisplayName("잘못된 roomId 형식 시 400을 반환한다")
     void getPricingPolicyInvalidRoomId() throws Exception {
       // when & then
-      mockMvc.perform(get("/api/pricing-policies/{roomId}", "invalid"))
+      mockMvc.perform(get("/api/v1/pricing-policies/{roomId}", "invalid"))
           .andExpect(status().isBadRequest());
     }
   }
@@ -133,7 +133,7 @@ class PricingPolicyControllerTest {
           .thenReturn(updatedPolicy);
 
       // when & then
-      mockMvc.perform(put("/api/pricing-policies/{roomId}/default-price", roomId)
+      mockMvc.perform(put("/api/v1/pricing-policies/{roomId}/default-price", roomId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isOk())
@@ -149,7 +149,7 @@ class PricingPolicyControllerTest {
           new BigDecimal("-1000"));
 
       // when & then
-      mockMvc.perform(put("/api/pricing-policies/{roomId}/default-price", roomId)
+      mockMvc.perform(put("/api/v1/pricing-policies/{roomId}/default-price", roomId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isBadRequest());
@@ -191,7 +191,7 @@ class PricingPolicyControllerTest {
           .thenReturn(updatedPolicy);
 
       // when & then
-      mockMvc.perform(put("/api/pricing-policies/{roomId}/time-range-prices", roomId)
+      mockMvc.perform(put("/api/v1/pricing-policies/{roomId}/time-range-prices", roomId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isOk())
@@ -223,7 +223,7 @@ class PricingPolicyControllerTest {
           .thenReturn(copiedPolicy);
 
       // when & then
-      mockMvc.perform(post("/api/pricing-policies/{targetRoomId}/copy", targetRoomId)
+      mockMvc.perform(post("/api/v1/pricing-policies/{targetRoomId}/copy", targetRoomId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isOk())
@@ -243,7 +243,7 @@ class PricingPolicyControllerTest {
               "Cannot copy pricing policy between different places"));
 
       // when & then
-      mockMvc.perform(post("/api/pricing-policies/{targetRoomId}/copy", targetRoomId)
+      mockMvc.perform(post("/api/v1/pricing-policies/{targetRoomId}/copy", targetRoomId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isBadRequest())
@@ -258,7 +258,7 @@ class PricingPolicyControllerTest {
       final String invalidRequest = "{\"sourceRoomId\": null}";
 
       // when & then
-      mockMvc.perform(post("/api/pricing-policies/{targetRoomId}/copy", targetRoomId)
+      mockMvc.perform(post("/api/v1/pricing-policies/{targetRoomId}/copy", targetRoomId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(invalidRequest))
           .andExpect(status().isBadRequest());

--- a/springProject/src/test/java/com/teambind/springproject/adapter/in/web/product/ProductControllerTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/adapter/in/web/product/ProductControllerTest.java
@@ -101,7 +101,7 @@ class ProductControllerTest {
           .thenReturn(response);
 
       // when & then
-      mockMvc.perform(post("/api/products")
+      mockMvc.perform(post("/api/v1/products")
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isCreated())
@@ -147,7 +147,7 @@ class ProductControllerTest {
           .thenReturn(response);
 
       // when & then
-      mockMvc.perform(post("/api/products")
+      mockMvc.perform(post("/api/v1/products")
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isCreated())
@@ -192,7 +192,7 @@ class ProductControllerTest {
           .thenReturn(response);
 
       // when & then
-      mockMvc.perform(post("/api/products")
+      mockMvc.perform(post("/api/v1/products")
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isCreated())
@@ -218,7 +218,7 @@ class ProductControllerTest {
       );
 
       // when & then
-      mockMvc.perform(post("/api/products")
+      mockMvc.perform(post("/api/v1/products")
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isBadRequest());
@@ -244,7 +244,7 @@ class ProductControllerTest {
       );
 
       // when & then
-      mockMvc.perform(post("/api/products")
+      mockMvc.perform(post("/api/v1/products")
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isBadRequest());
@@ -273,7 +273,7 @@ class ProductControllerTest {
       when(getProductUseCase.getById(any(ProductId.class))).thenReturn(response);
 
       // when & then
-      mockMvc.perform(get("/api/products/{productId}", productId))
+      mockMvc.perform(get("/api/v1/products/{productId}", productId))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.productId").value(productId))
           .andExpect(jsonPath("$.name").value("테스트 상품"));
@@ -289,7 +289,7 @@ class ProductControllerTest {
           .thenThrow(new NoSuchElementException("Product not found"));
 
       // when & then
-      mockMvc.perform(get("/api/products/{productId}", productId))
+      mockMvc.perform(get("/api/v1/products/{productId}", productId))
           .andExpect(status().isNotFound());
     }
 
@@ -297,7 +297,7 @@ class ProductControllerTest {
     @DisplayName("음수 ID 조회 시 400을 반환한다")
     void getProductWithNegativeId() throws Exception {
       // when & then
-      mockMvc.perform(get("/api/products/{productId}", -1))
+      mockMvc.perform(get("/api/v1/products/{productId}", -1))
           .andExpect(status().isBadRequest());
     }
   }
@@ -320,7 +320,7 @@ class ProductControllerTest {
       when(getProductUseCase.getAll()).thenReturn(responses);
 
       // when & then
-      mockMvc.perform(get("/api/products"))
+      mockMvc.perform(get("/api/v1/products"))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.length()").value(2));
     }
@@ -337,7 +337,7 @@ class ProductControllerTest {
       when(getProductUseCase.getByScope(ProductScope.PLACE)).thenReturn(responses);
 
       // when & then
-      mockMvc.perform(get("/api/products").param("scope", "PLACE"))
+      mockMvc.perform(get("/api/v1/products").param("scope", "PLACE"))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.length()").value(1))
           .andExpect(jsonPath("$[0].scope").value("PLACE"));
@@ -355,7 +355,7 @@ class ProductControllerTest {
       when(getProductUseCase.getByPlaceId(any(PlaceId.class))).thenReturn(responses);
 
       // when & then
-      mockMvc.perform(get("/api/products").param("placeId", "100"))
+      mockMvc.perform(get("/api/v1/products").param("placeId", "100"))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.length()").value(1))
           .andExpect(jsonPath("$[0].placeId").value(100));
@@ -373,7 +373,7 @@ class ProductControllerTest {
       when(getProductUseCase.getByRoomId(any(RoomId.class))).thenReturn(responses);
 
       // when & then
-      mockMvc.perform(get("/api/products").param("roomId", "200"))
+      mockMvc.perform(get("/api/v1/products").param("roomId", "200"))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.length()").value(1))
           .andExpect(jsonPath("$[0].roomId").value(200));
@@ -409,7 +409,7 @@ class ProductControllerTest {
           .thenReturn(response);
 
       // when & then
-      mockMvc.perform(put("/api/products/{productId}", productId)
+      mockMvc.perform(put("/api/v1/products/{productId}", productId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isOk())
@@ -433,7 +433,7 @@ class ProductControllerTest {
           .thenThrow(new NoSuchElementException("Product not found"));
 
       // when & then
-      mockMvc.perform(put("/api/products/{productId}", productId)
+      mockMvc.perform(put("/api/v1/products/{productId}", productId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isNotFound());
@@ -453,7 +453,7 @@ class ProductControllerTest {
       doNothing().when(deleteProductUseCase).delete(any(ProductId.class));
 
       // when & then
-      mockMvc.perform(delete("/api/products/{productId}", productId))
+      mockMvc.perform(delete("/api/v1/products/{productId}", productId))
           .andExpect(status().isNoContent());
     }
 
@@ -467,7 +467,7 @@ class ProductControllerTest {
           .when(deleteProductUseCase).delete(any(ProductId.class));
 
       // when & then
-      mockMvc.perform(delete("/api/products/{productId}", productId))
+      mockMvc.perform(delete("/api/v1/products/{productId}", productId))
           .andExpect(status().isNotFound());
     }
   }

--- a/springProject/src/test/java/com/teambind/springproject/adapter/in/web/reservationpricing/ReservationPricingControllerTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/adapter/in/web/reservationpricing/ReservationPricingControllerTest.java
@@ -52,7 +52,7 @@ class ReservationPricingControllerTest {
   private UpdateReservationProductsUseCase updateReservationProductsUseCase;
 
   @Nested
-  @DisplayName("POST /api/reservations/pricing - 예약 생성")
+  @DisplayName("POST /api/v1/reservations - 예약 생성")
   class CreateReservationTests {
 
     @Test
@@ -81,7 +81,7 @@ class ReservationPricingControllerTest {
           .thenReturn(response);
 
       // when & then
-      mockMvc.perform(post("/api/reservations/pricing")
+      mockMvc.perform(post("/api/v1/reservations")
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isCreated())
@@ -108,7 +108,7 @@ class ReservationPricingControllerTest {
           .thenThrow(new ProductNotAvailableException(1L, 100));
 
       // when & then
-      mockMvc.perform(post("/api/reservations/pricing")
+      mockMvc.perform(post("/api/v1/reservations")
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isBadRequest())
@@ -129,7 +129,7 @@ class ReservationPricingControllerTest {
       );
 
       // when & then
-      mockMvc.perform(post("/api/reservations/pricing")
+      mockMvc.perform(post("/api/v1/reservations")
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isBadRequest());
@@ -157,7 +157,7 @@ class ReservationPricingControllerTest {
           .thenReturn(response);
 
       // when & then
-      mockMvc.perform(put("/api/reservations/{reservationId}/confirm", reservationId))
+      mockMvc.perform(put("/api/v1/reservations/{reservationId}/confirm", reservationId))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.reservationId").value(1))
           .andExpect(jsonPath("$.status").value("CONFIRMED"));
@@ -173,7 +173,7 @@ class ReservationPricingControllerTest {
           .thenThrow(new ReservationPricingNotFoundException(reservationId));
 
       // when & then
-      mockMvc.perform(put("/api/reservations/{reservationId}/confirm", reservationId))
+      mockMvc.perform(put("/api/v1/reservations/{reservationId}/confirm", reservationId))
           .andExpect(status().isNotFound())
           .andExpect(jsonPath("$.code").value("RESERVATION_001"))
           .andExpect(jsonPath("$.exceptionType").value("ReservationPricingNotFoundException"));
@@ -201,7 +201,7 @@ class ReservationPricingControllerTest {
           .thenReturn(response);
 
       // when & then
-      mockMvc.perform(put("/api/reservations/{reservationId}/cancel", reservationId))
+      mockMvc.perform(put("/api/v1/reservations/{reservationId}/cancel", reservationId))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.reservationId").value(1))
           .andExpect(jsonPath("$.status").value("CANCELLED"));
@@ -217,7 +217,7 @@ class ReservationPricingControllerTest {
           .thenThrow(new ReservationPricingNotFoundException(reservationId));
 
       // when & then
-      mockMvc.perform(put("/api/reservations/{reservationId}/cancel", reservationId))
+      mockMvc.perform(put("/api/v1/reservations/{reservationId}/cancel", reservationId))
           .andExpect(status().isNotFound())
           .andExpect(jsonPath("$.code").value("RESERVATION_001"))
           .andExpect(jsonPath("$.exceptionType").value("ReservationPricingNotFoundException"));
@@ -253,7 +253,7 @@ class ReservationPricingControllerTest {
           .thenReturn(response);
 
       // when & then
-      mockMvc.perform(put("/api/reservations/{reservationId}/products", reservationId)
+      mockMvc.perform(put("/api/v1/reservations/{reservationId}/products", reservationId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isOk())
@@ -278,7 +278,7 @@ class ReservationPricingControllerTest {
           .thenThrow(new InvalidReservationStatusException(ReservationStatus.CONFIRMED, "updateProducts"));
 
       // when & then
-      mockMvc.perform(put("/api/reservations/{reservationId}/products", reservationId)
+      mockMvc.perform(put("/api/v1/reservations/{reservationId}/products", reservationId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isBadRequest())
@@ -302,7 +302,7 @@ class ReservationPricingControllerTest {
           .thenThrow(new ReservationPricingNotFoundException(reservationId));
 
       // when & then
-      mockMvc.perform(put("/api/reservations/{reservationId}/products", reservationId)
+      mockMvc.perform(put("/api/v1/reservations/{reservationId}/products", reservationId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isNotFound())
@@ -326,7 +326,7 @@ class ReservationPricingControllerTest {
           .thenThrow(new ProductNotAvailableException(1L, 100));
 
       // when & then
-      mockMvc.perform(put("/api/reservations/{reservationId}/products", reservationId)
+      mockMvc.perform(put("/api/v1/reservations/{reservationId}/products", reservationId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isBadRequest())
@@ -346,7 +346,7 @@ class ReservationPricingControllerTest {
       );
 
       // when & then
-      mockMvc.perform(put("/api/reservations/{reservationId}/products", invalidReservationId)
+      mockMvc.perform(put("/api/v1/reservations/{reservationId}/products", invalidReservationId)
               .contentType(MediaType.APPLICATION_JSON)
               .content(objectMapper.writeValueAsString(request)))
           .andExpect(status().isBadRequest());

--- a/springProject/src/test/java/com/teambind/springproject/common/exceptions/GlobalExceptionHandlerTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/common/exceptions/GlobalExceptionHandlerTest.java
@@ -47,12 +47,12 @@ class GlobalExceptionHandlerTest {
           .thenThrow(new IllegalArgumentException("Room ID cannot be null"));
 
       // when & then
-      mockMvc.perform(get("/api/pricing-policies/1"))
+      mockMvc.perform(get("/api/v1/pricing-policies/1"))
           .andExpect(status().isBadRequest())
           .andExpect(jsonPath("$.status").value(400))
           .andExpect(jsonPath("$.code").value("INVALID_ARGUMENT"))
           .andExpect(jsonPath("$.message").value("Room ID cannot be null"))
-          .andExpect(jsonPath("$.path").value("/api/pricing-policies/1"))
+          .andExpect(jsonPath("$.path").value("/api/v1/pricing-policies/1"))
           .andExpect(jsonPath("$.timestamp").exists());
     }
 
@@ -65,7 +65,7 @@ class GlobalExceptionHandlerTest {
           .thenThrow(new IllegalArgumentException(errorMessage));
 
       // when & then
-      mockMvc.perform(get("/api/pricing-policies/123"))
+      mockMvc.perform(get("/api/v1/pricing-policies/123"))
           .andExpect(status().isBadRequest())
           .andExpect(jsonPath("$.code").value("INVALID_ARGUMENT"))
           .andExpect(jsonPath("$.message").value(errorMessage));
@@ -84,12 +84,12 @@ class GlobalExceptionHandlerTest {
           .thenThrow(new IllegalStateException("Cannot modify confirmed pricing policy"));
 
       // when & then
-      mockMvc.perform(get("/api/pricing-policies/1"))
+      mockMvc.perform(get("/api/v1/pricing-policies/1"))
           .andExpect(status().isConflict())
           .andExpect(jsonPath("$.status").value(409))
           .andExpect(jsonPath("$.code").value("INVALID_STATE"))
           .andExpect(jsonPath("$.message").value("Cannot modify confirmed pricing policy"))
-          .andExpect(jsonPath("$.path").value("/api/pricing-policies/1"))
+          .andExpect(jsonPath("$.path").value("/api/v1/pricing-policies/1"))
           .andExpect(jsonPath("$.timestamp").exists());
     }
   }
@@ -106,7 +106,7 @@ class GlobalExceptionHandlerTest {
           .thenThrow(new IllegalArgumentException("Test error"));
 
       // when & then
-      mockMvc.perform(get("/api/pricing-policies/999"))
+      mockMvc.perform(get("/api/v1/pricing-policies/999"))
           .andExpect(status().isBadRequest())
           .andExpect(jsonPath("$.timestamp").exists())
           .andExpect(jsonPath("$.status").exists())
@@ -123,7 +123,7 @@ class GlobalExceptionHandlerTest {
           .thenThrow(new IllegalArgumentException("Invalid input"));
 
       // when & then
-      mockMvc.perform(get("/api/pricing-policies/1"))
+      mockMvc.perform(get("/api/v1/pricing-policies/1"))
           .andExpect(status().isBadRequest())
           .andExpect(jsonPath("$.fieldErrors").doesNotExist());
     }

--- a/springProject/src/test/java/com/teambind/springproject/e2e/InventoryManagementE2ETest.java
+++ b/springProject/src/test/java/com/teambind/springproject/e2e/InventoryManagementE2ETest.java
@@ -75,7 +75,7 @@ class InventoryManagementE2ETest extends BaseE2ETest {
     );
 
     final ResponseEntity<ReservationPricingResponse> response = restTemplate.postForEntity(
-        getBaseUrl() + "/api/reservations/pricing",
+        getBaseUrl() + "/api/v1/reservations",
         request,
         ReservationPricingResponse.class
     );
@@ -100,7 +100,7 @@ class InventoryManagementE2ETest extends BaseE2ETest {
     );
 
     final ResponseEntity<ReservationPricingResponse> response = restTemplate.postForEntity(
-        getBaseUrl() + "/api/reservations/pricing",
+        getBaseUrl() + "/api/v1/reservations",
         request,
         ReservationPricingResponse.class
     );
@@ -125,7 +125,7 @@ class InventoryManagementE2ETest extends BaseE2ETest {
     );
 
     final ResponseEntity<ReservationPricingResponse> response1 = restTemplate.postForEntity(
-        getBaseUrl() + "/api/reservations/pricing",
+        getBaseUrl() + "/api/v1/reservations",
         request1,
         ReservationPricingResponse.class
     );
@@ -141,7 +141,7 @@ class InventoryManagementE2ETest extends BaseE2ETest {
     );
 
     final ResponseEntity<ReservationPricingResponse> response2 = restTemplate.postForEntity(
-        getBaseUrl() + "/api/reservations/pricing",
+        getBaseUrl() + "/api/v1/reservations",
         request2,
         ReservationPricingResponse.class
     );

--- a/springProject/src/test/java/com/teambind/springproject/e2e/PriceImmutabilityE2ETest.java
+++ b/springProject/src/test/java/com/teambind/springproject/e2e/PriceImmutabilityE2ETest.java
@@ -70,7 +70,7 @@ class PriceImmutabilityE2ETest extends BaseE2ETest {
     );
 
     final ResponseEntity<ReservationPricingResponse> createResponse = restTemplate.postForEntity(
-        getBaseUrl() + "/api/reservations/pricing",
+        getBaseUrl() + "/api/v1/reservations",
         createRequest,
         ReservationPricingResponse.class
     );
@@ -81,7 +81,7 @@ class PriceImmutabilityE2ETest extends BaseE2ETest {
 
     // When: 예약 확정
     restTemplate.exchange(
-        getBaseUrl() + "/api/reservations/" + reservationId + "/confirm",
+        getBaseUrl() + "/api/v1/reservations/" + reservationId + "/confirm",
         org.springframework.http.HttpMethod.PUT,
         null,
         ReservationPricingResponse.class
@@ -113,7 +113,7 @@ class PriceImmutabilityE2ETest extends BaseE2ETest {
     );
 
     final ResponseEntity<ReservationPricingResponse> createResponse = restTemplate.postForEntity(
-        getBaseUrl() + "/api/reservations/pricing",
+        getBaseUrl() + "/api/v1/reservations",
         createRequest,
         ReservationPricingResponse.class
     );
@@ -124,7 +124,7 @@ class PriceImmutabilityE2ETest extends BaseE2ETest {
 
     // When: 예약 확정
     restTemplate.exchange(
-        getBaseUrl() + "/api/reservations/" + reservationId + "/confirm",
+        getBaseUrl() + "/api/v1/reservations/" + reservationId + "/confirm",
         org.springframework.http.HttpMethod.PUT,
         null,
         ReservationPricingResponse.class

--- a/springProject/src/test/java/com/teambind/springproject/e2e/ReservationFlowE2ETest.java
+++ b/springProject/src/test/java/com/teambind/springproject/e2e/ReservationFlowE2ETest.java
@@ -80,9 +80,9 @@ class ReservationFlowE2ETest extends BaseE2ETest {
         List.of(new ProductRequest(testProductId, 2))
     );
 
-    // When: POST /api/reservations/pricing
+    // When: POST /api/v1/reservations
     final ResponseEntity<ReservationPricingResponse> createResponse = restTemplate.postForEntity(
-        getBaseUrl() + "/api/reservations/pricing",
+        getBaseUrl() + "/api/v1/reservations",
         createRequest,
         ReservationPricingResponse.class
     );
@@ -98,7 +98,7 @@ class ReservationFlowE2ETest extends BaseE2ETest {
 
     // When: Confirm the reservation - PUT /api/reservations/{id}/confirm
     final ResponseEntity<ReservationPricingResponse> confirmResponse = restTemplate.exchange(
-        getBaseUrl() + "/api/reservations/" + reservationId + "/confirm",
+        getBaseUrl() + "/api/v1/reservations/" + reservationId + "/confirm",
         org.springframework.http.HttpMethod.PUT,
         null,
         ReservationPricingResponse.class
@@ -128,7 +128,7 @@ class ReservationFlowE2ETest extends BaseE2ETest {
     );
 
     final ResponseEntity<ReservationPricingResponse> createResponse = restTemplate.postForEntity(
-        getBaseUrl() + "/api/reservations/pricing",
+        getBaseUrl() + "/api/v1/reservations",
         createRequest,
         ReservationPricingResponse.class
     );
@@ -138,7 +138,7 @@ class ReservationFlowE2ETest extends BaseE2ETest {
 
     // When: Cancel the reservation - PUT /api/reservations/{id}/cancel
     final ResponseEntity<ReservationPricingResponse> cancelResponse = restTemplate.exchange(
-        getBaseUrl() + "/api/reservations/" + reservationId + "/cancel",
+        getBaseUrl() + "/api/v1/reservations/" + reservationId + "/cancel",
         org.springframework.http.HttpMethod.PUT,
         null,
         ReservationPricingResponse.class
@@ -168,7 +168,7 @@ class ReservationFlowE2ETest extends BaseE2ETest {
     );
 
     final ResponseEntity<ReservationPricingResponse> createResponse = restTemplate.postForEntity(
-        getBaseUrl() + "/api/reservations/pricing",
+        getBaseUrl() + "/api/v1/reservations",
         createRequest,
         ReservationPricingResponse.class
     );

--- a/springProject/src/test/java/com/teambind/springproject/e2e/RoomAllowedProductE2ETest.java
+++ b/springProject/src/test/java/com/teambind/springproject/e2e/RoomAllowedProductE2ETest.java
@@ -86,7 +86,7 @@ class RoomAllowedProductE2ETest extends BaseE2ETest {
 
     // When: 룸A에서 상품 가용성 조회
     final ResponseEntity<ProductAvailabilityResponse> response = restTemplate.getForEntity(
-        getBaseUrl() + "/api/products/availability?roomId=" + testRoomAId
+        getBaseUrl() + "/api/v1/products/availability?roomId=" + testRoomAId
             + "&placeId=" + testPlaceId
             + "&timeSlots=" + slot,
         ProductAvailabilityResponse.class
@@ -115,7 +115,7 @@ class RoomAllowedProductE2ETest extends BaseE2ETest {
 
     // When: 룸B에서 상품 가용성 조회
     final ResponseEntity<ProductAvailabilityResponse> response = restTemplate.getForEntity(
-        getBaseUrl() + "/api/products/availability?roomId=" + testRoomBId
+        getBaseUrl() + "/api/v1/products/availability?roomId=" + testRoomBId
             + "&placeId=" + testPlaceId
             + "&timeSlots=" + slot,
         ProductAvailabilityResponse.class


### PR DESCRIPTION
## Summary

Improved API endpoint design following RESTful principles and added v1 versioning to all endpoints.

## Changes

### RESTful API Improvements

**Before**:
```
POST   /api/reservations/pricing        ❌ /pricing redundant
POST   /api/reservations/pricing/preview ❌ nested unnecessarily
```

**After**:
```
POST   /api/v1/reservations           ✅ Clean, resource-centric
POST   /api/v1/reservations/preview   ✅ Consistent hierarchy
```

### API Versioning

All endpoints now include `/v1` version prefix:

| Old Endpoint | New Endpoint |
|--------------|--------------|
| `/api/reservations` | `/api/v1/reservations` |
| `/api/products` | `/api/v1/products` |
| `/api/pricing-policies` | `/api/v1/pricing-policies` |
| `/api/admin/...` | `/api/v1/admin/...` |

## Benefits

- **Resource-centric design**: URLs represent resources, not actions
- **Consistency**: All endpoints follow same pattern
- **Versioning support**: Easy to add v2 in the future
- **RESTful compliance**: Follows REST best practices

## Breaking Changes

- All API endpoints now require `/v1` prefix
- `POST /api/reservations/pricing` → `POST /api/v1/reservations`
- `POST /api/reservations/pricing/preview` → `POST /api/v1/reservations/preview`

## Testing

- ✅ Updated 4 Controller integration tests
- ✅ Updated 5 E2E tests
- ✅ Updated 1 GlobalExceptionHandler test
- ✅ All 511 tests passing
- ✅ Build successful

## Migration Guide

Clients need to update all API calls:

```diff
- POST /api/reservations/pricing
+ POST /api/v1/reservations

- POST /api/reservations/pricing/preview
+ POST /api/v1/reservations/preview

- GET /api/products
+ GET /api/v1/products
```

Closes #119