### PR TITLE
[2단계] Repository - 시간대별 재고 관리 메서드 추가

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/adapter/out/persistence/product/ProductRepositoryAdapter.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/out/persistence/product/ProductRepositoryAdapter.java
@@ -10,6 +10,7 @@ import com.teambind.springproject.domain.shared.RoomId;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -162,6 +163,123 @@ public class ProductRepositoryAdapter implements ProductRepository {
 				sql,
 				quantity,
 				productId.getValue(),
+				quantity
+		);
+
+		return updatedRows > 0;
+	}
+
+	@Override
+	public boolean reserveRoomTimeSlotQuantity(
+			final ProductId productId,
+			final RoomId roomId,
+			final LocalDateTime timeSlot,
+			final int quantity) {
+		if (quantity <= 0) {
+			throw new IllegalArgumentException("Quantity must be positive: " + quantity);
+		}
+
+		final String sql = """
+				INSERT INTO product_time_slot_inventory
+				    (product_id, room_id, time_slot, reserved_quantity)
+				VALUES (?, ?, ?, ?)
+				ON CONFLICT (product_id, room_id, time_slot)
+				DO UPDATE SET
+				    reserved_quantity = product_time_slot_inventory.reserved_quantity + EXCLUDED.reserved_quantity,
+				    updated_at = NOW()
+				WHERE EXISTS (
+				    SELECT 1 FROM products p
+				    WHERE p.product_id = EXCLUDED.product_id
+				      AND (p.total_quantity - COALESCE(
+				          (SELECT SUM(reserved_quantity)
+				           FROM product_time_slot_inventory
+				           WHERE product_id = EXCLUDED.product_id
+				             AND room_id = EXCLUDED.room_id
+				             AND time_slot = EXCLUDED.time_slot),
+				          0
+				      )) >= EXCLUDED.reserved_quantity
+				)
+				""";
+
+		final int updatedRows = jdbcTemplate.update(
+				sql,
+				productId.getValue(),
+				roomId.getValue(),
+				timeSlot,
+				quantity
+		);
+
+		return updatedRows > 0;
+	}
+
+	@Override
+	public boolean reservePlaceTimeSlotQuantity(
+			final ProductId productId,
+			final RoomId roomId,
+			final LocalDateTime timeSlot,
+			final int quantity) {
+		if (quantity <= 0) {
+			throw new IllegalArgumentException("Quantity must be positive: " + quantity);
+		}
+
+		final String sql = """
+				INSERT INTO product_time_slot_inventory
+				    (product_id, room_id, time_slot, reserved_quantity)
+				VALUES (?, ?, ?, ?)
+				ON CONFLICT (product_id, room_id, time_slot)
+				DO UPDATE SET
+				    reserved_quantity = product_time_slot_inventory.reserved_quantity + EXCLUDED.reserved_quantity,
+				    updated_at = NOW()
+				WHERE EXISTS (
+				    SELECT 1 FROM products p
+				    WHERE p.product_id = EXCLUDED.product_id
+				      AND (p.total_quantity - COALESCE(
+				          (SELECT SUM(reserved_quantity)
+				           FROM product_time_slot_inventory
+				           WHERE product_id = EXCLUDED.product_id
+				             AND time_slot = EXCLUDED.time_slot),
+				          0
+				      )) >= EXCLUDED.reserved_quantity
+				)
+				""";
+
+		final int updatedRows = jdbcTemplate.update(
+				sql,
+				productId.getValue(),
+				roomId.getValue(),
+				timeSlot,
+				quantity
+		);
+
+		return updatedRows > 0;
+	}
+
+	@Override
+	public boolean releaseTimeSlotQuantity(
+			final ProductId productId,
+			final RoomId roomId,
+			final LocalDateTime timeSlot,
+			final int quantity) {
+		if (quantity <= 0) {
+			throw new IllegalArgumentException("Quantity must be positive: " + quantity);
+		}
+
+		final String sql = """
+				UPDATE product_time_slot_inventory
+				SET reserved_quantity = reserved_quantity - ?,
+				    updated_at = NOW()
+				WHERE product_id = ?
+				  AND room_id = ?
+				  AND time_slot = ?
+				  AND reserved_quantity >= ?
+				""";
+
+		final int updatedRows = jdbcTemplate.update(
+				sql,
+				quantity,
+				productId.getValue(),
+				roomId.getValue(),
+				timeSlot,
 				quantity
 		);
 


### PR DESCRIPTION
## Summary
- ROOM/PLACE Scope 시간대별 재고 관리를 위한 Repository 메서드 추가
- INSERT ON CONFLICT UPDATE 패턴으로 원자적 재고 예약 구현

## Changes
- ProductRepository 인터페이스 확장
  - `reserveRoomTimeSlotQuantity()` - ROOM Scope 시간대별 재고 예약
  - `reservePlaceTimeSlotQuantity()` - PLACE Scope 시간대별 재고 예약
  - `releaseTimeSlotQuantity()` - 시간대별 재고 해제

- ProductRepositoryAdapter 구현
  - UPSERT 패턴 (INSERT ON CONFLICT DO UPDATE)
  - EXISTS 서브쿼리로 재고 검증
  - 원자적 UPDATE로 Race Condition 방지

## Test plan
- [x] 컴파일 성공 확인
- [ ] 다음 단계(Service)에서 통합 테스트

Related to #157