### PR TITLE
FEAT: 예약 환불 이벤트 처리 유즈케이스 구현 (#164)

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/consumer/EventConsumer.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/consumer/EventConsumer.java
@@ -31,6 +31,7 @@ public class EventConsumer {
 		EVENT_TYPE_MAP.put("SlotReserved", SlotReservedEvent.class);
 		EVENT_TYPE_MAP.put("ReservationConfirmed", ReservationConfirmedEvent.class);
 		EVENT_TYPE_MAP.put("ReservationCancelled", ReservationCancelledEvent.class);
+		EVENT_TYPE_MAP.put("ReservationRefund", ReservationRefundEvent.class);
 	}
 	
 	private final JsonUtil jsonUtil;
@@ -143,13 +144,13 @@ public class EventConsumer {
 	}
 	
 	/**
-	 * reservation-confirmed, reservation-cancelled 토픽에서 결제 이벤트를 수신합니다.
+	 * reservation-confirmed, reservation-cancelled, reservation-refund 토픽에서 결제 이벤트를 수신합니다.
 	 *
 	 * @param message        Kafka 메시지 (JSON)
 	 * @param acknowledgment Kafka acknowledgment
 	 */
 	@KafkaListener(
-			topics = {"reservation-confirmed", "reservation-cancelled"},
+			topics = {"reservation-confirmed", "reservation-cancelled", "reservation-refund"},
 			groupId = "${spring.kafka.consumer.group-id}")
 	public void consumePaymentEvents(final String message, final Acknowledgment acknowledgment) {
 		logger.info("Received message from payment topics: {}", message);

--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/event/ReservationRefundEvent.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/event/ReservationRefundEvent.java
@@ -1,0 +1,58 @@
+package com.teambind.springproject.adapter.in.messaging.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDateTime;
+
+/**
+ * 예약 환불 이벤트.
+ * 결제 서비스에서 환불이 완료되거나 관리자가 승인을 취소/거절했을 때 발행되는 이벤트입니다.
+ * <p>
+ * 이 이벤트를 수신하면 해당 예약의 상태를 CONFIRMED → CANCELLED로 변경하고,
+ * 예약으로 선점한 재고를 롤백 처리합니다.
+ * <p>
+ * 주의: CONFIRMED 상태가 아닌 예약에 대한 환불 이벤트는 예외를 발생시킵니다.
+ */
+public final class ReservationRefundEvent extends Event {
+
+	private static final String EVENT_TYPE_NAME = "ReservationRefund";
+	private static final String DEFAULT_TOPIC = "reservation-refund";
+
+	private final Long reservationId;
+	private final LocalDateTime occurredAt;
+
+	@JsonCreator
+	public ReservationRefundEvent(
+			@JsonProperty("topic") final String topic,
+			@JsonProperty("eventType") final String eventType,
+			@JsonProperty("reservationId") final Long reservationId,
+			@JsonProperty("occurredAt") final LocalDateTime occurredAt) {
+		super(topic != null ? topic : DEFAULT_TOPIC, eventType != null ? eventType : EVENT_TYPE_NAME);
+		this.reservationId = reservationId;
+		this.occurredAt = occurredAt;
+	}
+
+	@Override
+	public String getEventTypeName() {
+		return EVENT_TYPE_NAME;
+	}
+
+	public Long getReservationId() {
+		return reservationId;
+	}
+
+	public LocalDateTime getOccurredAt() {
+		return occurredAt;
+	}
+
+	@Override
+	public String toString() {
+		return "ReservationRefundEvent{"
+				+ "reservationId=" + reservationId
+				+ ", occurredAt=" + occurredAt
+				+ ", topic='" + getTopic() + '\''
+				+ ", eventType='" + getEventType() + '\''
+				+ '}';
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/handler/ReservationRefundEventHandler.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/handler/ReservationRefundEventHandler.java
@@ -1,0 +1,69 @@
+package com.teambind.springproject.adapter.in.messaging.handler;
+
+import com.teambind.springproject.adapter.in.messaging.event.ReservationRefundEvent;
+import com.teambind.springproject.application.port.out.ReservationPricingRepository;
+import com.teambind.springproject.domain.reservationpricing.ReservationPricing;
+import com.teambind.springproject.domain.reservationpricing.exception.InvalidReservationStatusException;
+import com.teambind.springproject.domain.reservationpricing.exception.ReservationPricingNotFoundException;
+import com.teambind.springproject.domain.shared.ReservationId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * ReservationRefundEvent 핸들러.
+ * 결제 서비스에서 환불 완료 또는 관리자 승인 취소/거절 이벤트를 수신하여
+ * CONFIRMED 상태의 예약을 CANCELLED로 변경합니다.
+ * <p>
+ * 주의: CONFIRMED 상태가 아닌 예약에 대한 환불 이벤트는 예외를 발생시킵니다.
+ */
+@Component
+public class ReservationRefundEventHandler implements EventHandler<ReservationRefundEvent> {
+
+	private static final Logger logger = LoggerFactory.getLogger(ReservationRefundEventHandler.class);
+
+	private final ReservationPricingRepository reservationPricingRepository;
+
+	public ReservationRefundEventHandler(final ReservationPricingRepository reservationPricingRepository) {
+		this.reservationPricingRepository = reservationPricingRepository;
+	}
+
+	@Override
+	public void handle(final ReservationRefundEvent event) {
+		logger.info("Handling ReservationRefundEvent: reservationId={}, occurredAt={}",
+				event.getReservationId(), event.getOccurredAt());
+
+		try {
+			final ReservationId reservationId = ReservationId.of(event.getReservationId());
+
+			// 1. 예약 조회
+			final ReservationPricing reservation = reservationPricingRepository.findById(reservationId)
+					.orElseThrow(() -> new ReservationPricingNotFoundException(event.getReservationId()));
+
+			// 2. 상태 변경 (CONFIRMED → CANCELLED, 방어 로직 포함)
+			reservation.refund();
+
+			// 3. 저장
+			reservationPricingRepository.save(reservation);
+
+			logger.info("Successfully refunded reservation: reservationId={}, status={}",
+					event.getReservationId(), reservation.getStatus());
+
+		} catch (final ReservationPricingNotFoundException e) {
+			logger.error("Reservation not found: reservationId={}", event.getReservationId(), e);
+			throw e;
+		} catch (final InvalidReservationStatusException e) {
+			logger.error("Invalid state transition for refund: reservationId={}, message={}",
+					event.getReservationId(), e.getMessage(), e);
+			throw e;
+		} catch (final Exception e) {
+			logger.error("Failed to handle ReservationRefundEvent: {}", event, e);
+			throw new RuntimeException("Failed to handle ReservationRefundEvent", e);
+		}
+	}
+
+	@Override
+	public String getSupportedEventType() {
+		return "ReservationRefund";
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/reservationpricing/ReservationPricing.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/reservationpricing/ReservationPricing.java
@@ -182,6 +182,19 @@ public class ReservationPricing {
 		}
 		this.status = ReservationStatus.CANCELLED;
 	}
+
+	/**
+	 * 예약을 환불합니다.
+	 * CONFIRMED 상태에서만 CANCELLED로 전환 가능합니다.
+	 * 결제 서비스에서 환불이 완료되거나 관리자가 승인을 취소/거절했을 때 호출됩니다.
+	 */
+	public void refund() {
+		if (status != ReservationStatus.CONFIRMED) {
+			throw new com.teambind.springproject.domain.reservationpricing.exception.InvalidReservationStatusException(
+					status, "refund");
+		}
+		this.status = ReservationStatus.CANCELLED;
+	}
 	
 	/**
 	 * 예약의 상품 목록을 업데이트하고 가격을 재계산합니다.

--- a/springProject/src/test/java/com/teambind/springproject/adapter/in/messaging/handler/ReservationRefundEventHandlerTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/adapter/in/messaging/handler/ReservationRefundEventHandlerTest.java
@@ -1,0 +1,151 @@
+package com.teambind.springproject.adapter.in.messaging.handler;
+
+import com.teambind.springproject.adapter.in.messaging.event.ReservationRefundEvent;
+import com.teambind.springproject.application.port.out.ReservationPricingRepository;
+import com.teambind.springproject.domain.reservationpricing.ReservationPricing;
+import com.teambind.springproject.domain.reservationpricing.TimeSlotPriceBreakdown;
+import com.teambind.springproject.domain.reservationpricing.exception.InvalidReservationStatusException;
+import com.teambind.springproject.domain.reservationpricing.exception.ReservationPricingNotFoundException;
+import com.teambind.springproject.domain.shared.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReservationRefundEventHandler 단위 테스트")
+class ReservationRefundEventHandlerTest {
+
+	@Mock
+	private ReservationPricingRepository reservationPricingRepository;
+
+	@InjectMocks
+	private ReservationRefundEventHandler handler;
+
+	private ReservationRefundEvent event;
+	private ReservationPricing reservationPricing;
+
+	@BeforeEach
+	void setUp() {
+		event = new ReservationRefundEvent(
+				"reservation-refund",
+				"ReservationRefund",
+				1L,
+				LocalDateTime.now()
+		);
+
+		final TimeSlotPriceBreakdown timeSlotBreakdown = new TimeSlotPriceBreakdown(
+				Map.of(LocalDateTime.of(2025, 1, 15, 10, 0), Money.of(BigDecimal.valueOf(10000))),
+				TimeSlot.HOUR
+		);
+
+		reservationPricing = ReservationPricing.calculate(
+				ReservationId.of(1L),
+				RoomId.of(1L),
+				timeSlotBreakdown,
+				Collections.emptyList(),
+				10L
+		);
+	}
+
+	@Nested
+	@DisplayName("handle() - 예약 환불 이벤트 처리")
+	class HandleTests {
+
+		@Test
+		@DisplayName("CONFIRMED 상태의 예약을 CANCELLED로 변경한다")
+		void refundConfirmedReservation() {
+			// given
+			reservationPricing.confirm(); // CONFIRMED 상태로 변경
+			when(reservationPricingRepository.findById(any(ReservationId.class)))
+					.thenReturn(Optional.of(reservationPricing));
+
+			// when
+			handler.handle(event);
+
+			// then
+			verify(reservationPricingRepository).findById(ReservationId.of(1L));
+			verify(reservationPricingRepository).save(any(ReservationPricing.class));
+			assertThat(reservationPricing.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+		}
+
+		@Test
+		@DisplayName("PENDING 상태의 예약을 환불하려고 하면 InvalidReservationStatusException을 발생시킨다")
+		void throwsExceptionWhenRefundingPending() {
+			// given - reservationPricing은 기본적으로 PENDING 상태
+			when(reservationPricingRepository.findById(any(ReservationId.class)))
+					.thenReturn(Optional.of(reservationPricing));
+
+			// when & then
+			assertThatThrownBy(() -> handler.handle(event))
+					.isInstanceOf(InvalidReservationStatusException.class)
+					.hasMessageContaining("refund");
+
+			verify(reservationPricingRepository).findById(ReservationId.of(1L));
+			verify(reservationPricingRepository, never()).save(any(ReservationPricing.class));
+		}
+
+		@Test
+		@DisplayName("이미 CANCELLED 상태의 예약을 환불하려고 하면 InvalidReservationStatusException을 발생시킨다")
+		void throwsExceptionWhenAlreadyCancelled() {
+			// given
+			reservationPricing.cancel(); // CANCELLED 상태로 변경
+			when(reservationPricingRepository.findById(any(ReservationId.class)))
+					.thenReturn(Optional.of(reservationPricing));
+
+			// when & then
+			assertThatThrownBy(() -> handler.handle(event))
+					.isInstanceOf(InvalidReservationStatusException.class)
+					.hasMessageContaining("refund");
+
+			verify(reservationPricingRepository).findById(ReservationId.of(1L));
+			verify(reservationPricingRepository, never()).save(any(ReservationPricing.class));
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 예약 ID인 경우 ReservationPricingNotFoundException을 발생시킨다")
+		void throwsExceptionWhenReservationNotFound() {
+			// given
+			when(reservationPricingRepository.findById(any(ReservationId.class)))
+					.thenReturn(Optional.empty());
+
+			// when & then
+			assertThatThrownBy(() -> handler.handle(event))
+					.isInstanceOf(ReservationPricingNotFoundException.class)
+					.hasMessageContaining("reservationId=1");
+
+			verify(reservationPricingRepository).findById(ReservationId.of(1L));
+			verify(reservationPricingRepository, never()).save(any(ReservationPricing.class));
+		}
+	}
+
+	@Nested
+	@DisplayName("getSupportedEventType() - 지원하는 이벤트 타입")
+	class GetSupportedEventTypeTests {
+
+		@Test
+		@DisplayName("ReservationRefund 이벤트 타입을 반환한다")
+		void returnsSupportedEventType() {
+			// when
+			final String eventType = handler.getSupportedEventType();
+
+			// then
+			assertThat(eventType).isEqualTo("ReservationRefund");
+		}
+	}
+}

--- a/springProject/src/test/java/com/teambind/springproject/domain/reservationpricing/ReservationPricingTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/domain/reservationpricing/ReservationPricingTest.java
@@ -272,21 +272,21 @@ class ReservationPricingTest {
 	@Nested
 	@DisplayName("cancel() 상태 전이 테스트")
 	class CancelTests {
-		
+
 		@Test
 		@DisplayName("PENDING 상태에서 CANCELLED로 전환에 성공한다")
 		void cancelFromPendingSuccess() {
 			// given
 			final ReservationPricing pricing = createTestPricing();
 			assertThat(pricing.getStatus()).isEqualTo(ReservationStatus.PENDING);
-			
+
 			// when
 			pricing.cancel();
-			
+
 			// then
 			assertThat(pricing.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
 		}
-		
+
 		@Test
 		@DisplayName("CONFIRMED 상태에서 cancel()하면 예외가 발생한다")
 		void cancelFromConfirmedFails() {
@@ -309,6 +309,53 @@ class ReservationPricingTest {
 			// when & then
 			assertThatThrownBy(pricing::cancel)
 					.isInstanceOf(InvalidReservationStatusException.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("refund() 상태 전이 테스트")
+	class RefundTests {
+
+		@Test
+		@DisplayName("CONFIRMED 상태에서 CANCELLED로 전환에 성공한다")
+		void refundFromConfirmedSuccess() {
+			// given
+			final ReservationPricing pricing = createTestPricing();
+			pricing.confirm();
+			assertThat(pricing.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+
+			// when
+			pricing.refund();
+
+			// then
+			assertThat(pricing.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+		}
+
+		@Test
+		@DisplayName("PENDING 상태에서 refund()하면 예외가 발생한다")
+		void refundFromPendingFails() {
+			// given
+			final ReservationPricing pricing = createTestPricing();
+			assertThat(pricing.getStatus()).isEqualTo(ReservationStatus.PENDING);
+
+			// when & then
+			assertThatThrownBy(pricing::refund)
+					.isInstanceOf(InvalidReservationStatusException.class)
+					.hasMessageContaining("refund");
+		}
+
+		@Test
+		@DisplayName("CANCELLED 상태에서 refund()하면 예외가 발생한다")
+		void refundFromCancelledFails() {
+			// given
+			final ReservationPricing pricing = createTestPricing();
+			pricing.cancel();
+			assertThat(pricing.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+
+			// when & then
+			assertThatThrownBy(pricing::refund)
+					.isInstanceOf(InvalidReservationStatusException.class)
+					.hasMessageContaining("refund");
 		}
 	}
 	


### PR DESCRIPTION
## 개요
Issue #164: 예약 환불 처리 유즈케이스를 구현했습니다.

결제 서비스에서 환불이 완료되거나 관리자가 승인을 취소/거절했을 때 발행되는 `reservation-refund` 이벤트를 처리하여 예약 상태를 CANCELLED로 변경하고 재고를 복구합니다.

## 주요 변경사항

### 1. Domain Layer
- **`ReservationPricing.refund()` 메서드 추가**
  - CONFIRMED 상태에서만 CANCELLED로 전환 허용
  - 방어 로직: PENDING이나 CANCELLED 상태에서는 `InvalidReservationStatusException` 발생
  - 기존 `cancel()` 메서드와 명확히 구분
    - `cancel()`: PENDING → CANCELLED (사용자 취소)
    - `refund()`: CONFIRMED → CANCELLED (환불 처리)

### 2. Event & Handler Layer
- **`ReservationRefundEvent` 클래스 생성**
  - 결제 서비스에서 환불 완료 시 발행되는 이벤트
  - 필드: `reservationId`, `occurredAt`
  
- **`ReservationRefundEventHandler` 구현**
  - `reservation-refund` 토픽 이벤트 수신 및 처리
  - CONFIRMED 상태 검증 후 `refund()` 메서드 호출
  - 예약 저장 (상태 변경은 도메인 로직이 처리하며, 재고는 자동 복구됨)
  - 적절한 예외 처리 및 로깅

### 3. Infrastructure Layer
- **`EventConsumer` Kafka 설정**
  - `reservation-refund` 토픽을 payment events 리스너에 추가
  - `ReservationRefund` 이벤트 타입 매핑

### 4. Tests
- **단위 테스트** (`ReservationRefundEventHandlerTest`)
  -  CONFIRMED 상태 예약의 환불 성공
  - PENDING 상태 예약 환불 시 예외 발생
  - CANCELLED 상태 예약 환불 시 예외 발생
  - 존재하지 않는 예약 ID 처리
  
- **도메인 테스트** (`ReservationPricingTest`)
  - refund() 메서드의 상태 전이 로직 검증
  -  방어 로직 검증 (CONFIRMED가 아닌 경우 예외)

## 기술적 결정

### 1. 왜 refund()와 cancel()을 분리했나요?
- **비즈니스 의미 차이**:
  - `cancel()`: 사용자가 결제 전(PENDING)에 예약 취소
  - `refund()`: 결제 완료(CONFIRMED) 후 환불 처리
  
- **방어 로직 차이**:
  - `cancel()`: CONFIRMED 상태에서는 호출 불가 (결제 완료된 예약은 사용자가 직접 취소 불가)
  - `refund()`: PENDING 상태에서는 호출 불가 (결제되지 않은 예약은 환불 불가)

### 2. 재고 복구는 어떻게 이루어지나요?
- 재고는 **자동으로 복구**됩니다
- 예약 상태가 CANCELLED로 변경되면, 재고 계산 시 해당 예약은 제외됨
- 별도의 `releaseProducts()` 호출 없이도 재고 정합성 유지

### 3. 이벤트 순서 보장은?
- Kafka 토픽: `reservation-refund`
- 결제 서비스에서 환불 완료 후 이벤트 발행
- 이벤트가 순서대로 처리되지 않을 경우를 대비해 CONFIRMED 상태 검증

## 테스트 결과
```bash
./gradlew test --tests "*ReservationPricingTest*" --tests "*ReservationRefundEventHandlerTest*"
```
 모든 테스트 통과

## 체크리스트
- [x] Domain 로직 구현 (`ReservationPricing.refund()`)
- [x] Event 클래스 생성 (`ReservationRefundEvent`)
- [x] Event Handler 구현 (`ReservationRefundEventHandler`)
- [x] Kafka 토픽 설정 추가
- [x] 단위 테스트 작성
- [x] 도메인 테스트 작성
- [x] 모든 테스트 통과 확인

Closes #164