### PR TITLE
[FEAT] Add API to retrieve available products for room

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/web/room/RoomProductController.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/web/room/RoomProductController.java
@@ -1,0 +1,54 @@
+package com.teambind.springproject.adapter.in.web.room;
+
+import com.teambind.springproject.application.dto.response.ProductResponse;
+import com.teambind.springproject.application.port.in.GetAvailableProductsForRoomUseCase;
+import com.teambind.springproject.domain.shared.PlaceId;
+import com.teambind.springproject.domain.shared.RoomId;
+import jakarta.validation.constraints.Positive;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 룸별 상품 조회 REST Controller.
+ *
+ * Room 리소스 중심의 RESTful API를 제공합니다.
+ * 일반 사용자가 특정 룸에서 예약 가능한 상품 목록을 조회하는 기능을 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/rooms/{roomId}/available-products")
+@Validated
+public class RoomProductController {
+
+	private final GetAvailableProductsForRoomUseCase getAvailableProductsForRoomUseCase;
+
+	public RoomProductController(
+			final GetAvailableProductsForRoomUseCase getAvailableProductsForRoomUseCase) {
+		this.getAvailableProductsForRoomUseCase = getAvailableProductsForRoomUseCase;
+	}
+
+	/**
+	 * 특정 룸에서 이용 가능한 상품 목록을 조회합니다.
+	 *
+	 * 조회되는 상품:
+	 * - ROOM Scope: 해당 roomId를 가진 상품
+	 * - PLACE Scope: RoomAllowedProduct에 허용된 상품
+	 * - RESERVATION Scope: 모든 룸에서 사용 가능한 상품
+	 *
+	 * @param roomId 룸 ID
+	 * @param placeId 플레이스 ID
+	 * @return 이용 가능한 상품 목록
+	 */
+	@GetMapping
+	public ResponseEntity<List<ProductResponse>> getAvailableProducts(
+			@PathVariable @Positive(message = "Room ID must be positive") final Long roomId,
+			@RequestParam @Positive(message = "Place ID must be positive") final Long placeId) {
+
+		final List<ProductResponse> responses = getAvailableProductsForRoomUseCase
+				.getAvailableProducts(RoomId.of(roomId), PlaceId.of(placeId));
+
+		return ResponseEntity.ok(responses);
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/application/port/in/GetAvailableProductsForRoomUseCase.java
+++ b/springProject/src/main/java/com/teambind/springproject/application/port/in/GetAvailableProductsForRoomUseCase.java
@@ -1,0 +1,31 @@
+package com.teambind.springproject.application.port.in;
+
+import com.teambind.springproject.application.dto.response.ProductResponse;
+import com.teambind.springproject.domain.shared.PlaceId;
+import com.teambind.springproject.domain.shared.RoomId;
+
+import java.util.List;
+
+/**
+ * 룸에서 이용 가능한 상품 조회 Use Case.
+ * Hexagonal Architecture의 입력 포트(Input Port)입니다.
+ *
+ * 일반 사용자가 예약 시 선택 가능한 상품 목록을 조회하는 기능을 제공합니다.
+ * 재고 정보는 포함하지 않으며, 단순 리스트업 용도입니다.
+ *
+ * 조회되는 상품:
+ * - ROOM Scope 상품: 해당 roomId를 가진 상품
+ * - PLACE Scope 상품: RoomAllowedProduct 테이블에 허용된 상품
+ * - RESERVATION Scope 상품: 모든 룸에서 사용 가능한 상품
+ */
+public interface GetAvailableProductsForRoomUseCase {
+
+	/**
+	 * 특정 룸에서 이용 가능한 모든 상품을 조회합니다.
+	 *
+	 * @param roomId 룸 ID
+	 * @param placeId 플레이스 ID
+	 * @return 이용 가능한 상품 목록
+	 */
+	List<ProductResponse> getAvailableProducts(RoomId roomId, PlaceId placeId);
+}

--- a/springProject/src/main/java/com/teambind/springproject/application/service/product/GetAvailableProductsForRoomService.java
+++ b/springProject/src/main/java/com/teambind/springproject/application/service/product/GetAvailableProductsForRoomService.java
@@ -1,0 +1,51 @@
+package com.teambind.springproject.application.service.product;
+
+import com.teambind.springproject.application.dto.response.ProductResponse;
+import com.teambind.springproject.application.port.in.GetAvailableProductsForRoomUseCase;
+import com.teambind.springproject.application.port.out.ProductRepository;
+import com.teambind.springproject.domain.product.Product;
+import com.teambind.springproject.domain.shared.PlaceId;
+import com.teambind.springproject.domain.shared.RoomId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 룸에서 이용 가능한 상품 조회 Application Service.
+ * GetAvailableProductsForRoomUseCase를 구현합니다.
+ *
+ * 이 서비스는 일반 사용자가 예약 시 선택 가능한 상품 목록을 제공합니다.
+ * ProductRepository.findAccessibleProducts()를 활용하여 다음 상품들을 조회합니다:
+ * - ROOM Scope: 해당 roomId를 가진 상품
+ * - PLACE Scope: placeId를 가지며 RoomAllowedProduct에 등록된 상품
+ * - RESERVATION Scope: 모든 룸에서 사용 가능한 상품
+ */
+@Service
+@Transactional(readOnly = true)
+public class GetAvailableProductsForRoomService implements GetAvailableProductsForRoomUseCase {
+
+	private static final Logger logger = LoggerFactory.getLogger(GetAvailableProductsForRoomService.class);
+
+	private final ProductRepository productRepository;
+
+	public GetAvailableProductsForRoomService(final ProductRepository productRepository) {
+		this.productRepository = productRepository;
+	}
+
+	@Override
+	public List<ProductResponse> getAvailableProducts(final RoomId roomId, final PlaceId placeId) {
+		logger.info("Fetching available products for roomId: {}, placeId: {}",
+				roomId.getValue(), placeId.getValue());
+
+		final List<Product> products = productRepository.findAccessibleProducts(placeId, roomId);
+
+		logger.info("Found {} available products for roomId: {}", products.size(), roomId.getValue());
+
+		return products.stream()
+				.map(ProductResponse::from)
+				.toList();
+	}
+}

--- a/springProject/src/test/java/com/teambind/springproject/adapter/in/web/room/RoomProductControllerTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/adapter/in/web/room/RoomProductControllerTest.java
@@ -1,0 +1,167 @@
+package com.teambind.springproject.adapter.in.web.room;
+
+import com.teambind.springproject.application.dto.request.PricingStrategyDto;
+import com.teambind.springproject.application.dto.response.ProductResponse;
+import com.teambind.springproject.application.port.in.GetAvailableProductsForRoomUseCase;
+import com.teambind.springproject.domain.product.vo.PricingType;
+import com.teambind.springproject.domain.product.vo.ProductScope;
+import com.teambind.springproject.domain.shared.PlaceId;
+import com.teambind.springproject.domain.shared.RoomId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RoomProductController.class)
+@DisplayName("RoomProductController 통합 테스트")
+class RoomProductControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private GetAvailableProductsForRoomUseCase getAvailableProductsForRoomUseCase;
+
+	@Nested
+	@DisplayName("GET /api/v1/rooms/{roomId}/available-products - 룸별 이용 가능 상품 조회")
+	class GetAvailableProductsTests {
+
+		@Test
+		@DisplayName("룸에서 이용 가능한 상품 조회에 성공한다")
+		void getAvailableProductsSuccess() throws Exception {
+			// Given
+			final Long roomId = 200L;
+			final Long placeId = 100L;
+
+			final List<ProductResponse> responses = List.of(
+					// ROOM Scope 상품
+					new ProductResponse(
+							1L,
+							ProductScope.ROOM,
+							placeId,
+							roomId,
+							"룸 전용 화이트보드",
+							new PricingStrategyDto(PricingType.ONE_TIME, BigDecimal.valueOf(15000), null),
+							3
+					),
+					// PLACE Scope 상품 (허용된 상품)
+					new ProductResponse(
+							2L,
+							ProductScope.PLACE,
+							placeId,
+							null,
+							"공용 빔 프로젝터",
+							new PricingStrategyDto(PricingType.SIMPLE_STOCK, BigDecimal.valueOf(10000), null),
+							5
+					),
+					// RESERVATION Scope 상품
+					new ProductResponse(
+							3L,
+							ProductScope.RESERVATION,
+							null,
+							null,
+							"음료수",
+							new PricingStrategyDto(PricingType.SIMPLE_STOCK, BigDecimal.valueOf(2000), null),
+							100
+					)
+			);
+
+			when(getAvailableProductsForRoomUseCase.getAvailableProducts(
+					any(RoomId.class),
+					any(PlaceId.class)
+			)).thenReturn(responses);
+
+			// When & Then
+			mockMvc.perform(get("/api/v1/rooms/{roomId}/available-products", roomId)
+							.param("placeId", placeId.toString()))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.length()").value(3))
+					.andExpect(jsonPath("$[0].productId").value(1))
+					.andExpect(jsonPath("$[0].scope").value("ROOM"))
+					.andExpect(jsonPath("$[0].roomId").value(roomId))
+					.andExpect(jsonPath("$[0].name").value("룸 전용 화이트보드"))
+					.andExpect(jsonPath("$[1].productId").value(2))
+					.andExpect(jsonPath("$[1].scope").value("PLACE"))
+					.andExpect(jsonPath("$[1].placeId").value(placeId))
+					.andExpect(jsonPath("$[1].name").value("공용 빔 프로젝터"))
+					.andExpect(jsonPath("$[2].productId").value(3))
+					.andExpect(jsonPath("$[2].scope").value("RESERVATION"))
+					.andExpect(jsonPath("$[2].name").value("음료수"));
+		}
+
+		@Test
+		@DisplayName("빈 목록 조회에 성공한다")
+		void getAvailableProductsEmptyList() throws Exception {
+			// Given
+			final Long roomId = 200L;
+			final Long placeId = 100L;
+
+			when(getAvailableProductsForRoomUseCase.getAvailableProducts(
+					any(RoomId.class),
+					any(PlaceId.class)
+			)).thenReturn(List.of());
+
+			// When & Then
+			mockMvc.perform(get("/api/v1/rooms/{roomId}/available-products", roomId)
+							.param("placeId", placeId.toString()))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.length()").value(0));
+		}
+
+		@Test
+		@DisplayName("음수 roomId 요청 시 400 Bad Request를 반환한다")
+		void getAvailableProductsWithNegativeRoomId() throws Exception {
+			// When & Then
+			mockMvc.perform(get("/api/v1/rooms/{roomId}/available-products", -1)
+							.param("placeId", "100"))
+					.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("음수 placeId 요청 시 400 Bad Request를 반환한다")
+		void getAvailableProductsWithNegativePlaceId() throws Exception {
+			// When & Then
+			mockMvc.perform(get("/api/v1/rooms/{roomId}/available-products", 200)
+							.param("placeId", "-1"))
+					.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("placeId 누락 시 400 Bad Request를 반환한다")
+		void getAvailableProductsWithoutPlaceId() throws Exception {
+			// When & Then
+			mockMvc.perform(get("/api/v1/rooms/{roomId}/available-products", 200))
+					.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("0 값의 roomId 요청 시 400 Bad Request를 반환한다")
+		void getAvailableProductsWithZeroRoomId() throws Exception {
+			// When & Then
+			mockMvc.perform(get("/api/v1/rooms/{roomId}/available-products", 0)
+							.param("placeId", "100"))
+					.andExpect(status().isBadRequest());
+		}
+
+		@Test
+		@DisplayName("0 값의 placeId 요청 시 400 Bad Request를 반환한다")
+		void getAvailableProductsWithZeroPlaceId() throws Exception {
+			// When & Then
+			mockMvc.perform(get("/api/v1/rooms/{roomId}/available-products", 200)
+							.param("placeId", "0"))
+					.andExpect(status().isBadRequest());
+		}
+	}
+}

--- a/springProject/src/test/java/com/teambind/springproject/application/service/product/GetAvailableProductsForRoomServiceTest.java
+++ b/springProject/src/test/java/com/teambind/springproject/application/service/product/GetAvailableProductsForRoomServiceTest.java
@@ -1,0 +1,203 @@
+package com.teambind.springproject.application.service.product;
+
+import com.teambind.springproject.application.dto.response.ProductResponse;
+import com.teambind.springproject.application.port.out.ProductRepository;
+import com.teambind.springproject.domain.product.Product;
+import com.teambind.springproject.domain.product.pricing.PricingStrategy;
+import com.teambind.springproject.domain.product.vo.PricingType;
+import com.teambind.springproject.domain.product.vo.ProductScope;
+import com.teambind.springproject.domain.shared.Money;
+import com.teambind.springproject.domain.shared.PlaceId;
+import com.teambind.springproject.domain.shared.ProductId;
+import com.teambind.springproject.domain.shared.RoomId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetAvailableProductsForRoomService 단위 테스트")
+class GetAvailableProductsForRoomServiceTest {
+
+	@Mock
+	private ProductRepository productRepository;
+
+	@InjectMocks
+	private GetAvailableProductsForRoomService service;
+
+	private PlaceId placeId;
+	private RoomId roomId;
+
+	@BeforeEach
+	void setUp() {
+		placeId = PlaceId.of(100L);
+		roomId = RoomId.of(200L);
+	}
+
+	@Nested
+	@DisplayName("getAvailableProducts 메서드는")
+	class GetAvailableProductsMethod {
+
+		@Test
+		@DisplayName("룸에서 이용 가능한 모든 상품을 조회한다")
+		void shouldReturnAllAvailableProducts() {
+			// Given
+			final Product roomProduct = Product.createRoomScoped(
+					ProductId.of(1L),
+					placeId,
+					roomId,
+					"룸 전용 화이트보드",
+					PricingStrategy.oneTime(Money.of(BigDecimal.valueOf(15000))),
+					3
+			);
+
+			final Product placeProduct = Product.createPlaceScoped(
+					ProductId.of(2L),
+					placeId,
+					"공용 빔 프로젝터",
+					PricingStrategy.simpleStock(Money.of(BigDecimal.valueOf(10000))),
+					5
+			);
+
+			final Product reservationProduct = Product.createReservationScoped(
+					ProductId.of(3L),
+					"음료수",
+					PricingStrategy.simpleStock(Money.of(BigDecimal.valueOf(2000))),
+					100
+			);
+
+			final List<Product> products = List.of(roomProduct, placeProduct, reservationProduct);
+
+			when(productRepository.findAccessibleProducts(any(PlaceId.class), any(RoomId.class)))
+					.thenReturn(products);
+
+			// When
+			final List<ProductResponse> result = service.getAvailableProducts(roomId, placeId);
+
+			// Then
+			assertThat(result).hasSize(3);
+
+			// ROOM Scope 상품 검증
+			final ProductResponse roomResponse = result.get(0);
+			assertThat(roomResponse.productId()).isEqualTo(1L);
+			assertThat(roomResponse.scope()).isEqualTo(ProductScope.ROOM);
+			assertThat(roomResponse.roomId()).isEqualTo(200L);
+			assertThat(roomResponse.placeId()).isEqualTo(100L);
+			assertThat(roomResponse.name()).isEqualTo("룸 전용 화이트보드");
+			assertThat(roomResponse.pricingStrategy().pricingType()).isEqualTo(PricingType.ONE_TIME);
+			assertThat(roomResponse.totalQuantity()).isEqualTo(3);
+
+			// PLACE Scope 상품 검증
+			final ProductResponse placeResponse = result.get(1);
+			assertThat(placeResponse.productId()).isEqualTo(2L);
+			assertThat(placeResponse.scope()).isEqualTo(ProductScope.PLACE);
+			assertThat(placeResponse.placeId()).isEqualTo(100L);
+			assertThat(placeResponse.roomId()).isNull();
+			assertThat(placeResponse.name()).isEqualTo("공용 빔 프로젝터");
+			assertThat(placeResponse.pricingStrategy().pricingType()).isEqualTo(PricingType.SIMPLE_STOCK);
+			assertThat(placeResponse.totalQuantity()).isEqualTo(5);
+
+			// RESERVATION Scope 상품 검증
+			final ProductResponse reservationResponse = result.get(2);
+			assertThat(reservationResponse.productId()).isEqualTo(3L);
+			assertThat(reservationResponse.scope()).isEqualTo(ProductScope.RESERVATION);
+			assertThat(reservationResponse.placeId()).isNull();
+			assertThat(reservationResponse.roomId()).isNull();
+			assertThat(reservationResponse.name()).isEqualTo("음료수");
+			assertThat(reservationResponse.pricingStrategy().pricingType()).isEqualTo(PricingType.SIMPLE_STOCK);
+			assertThat(reservationResponse.totalQuantity()).isEqualTo(100);
+
+			verify(productRepository).findAccessibleProducts(placeId, roomId);
+		}
+
+		@Test
+		@DisplayName("이용 가능한 상품이 없으면 빈 리스트를 반환한다")
+		void shouldReturnEmptyListWhenNoProductsAvailable() {
+			// Given
+			when(productRepository.findAccessibleProducts(any(PlaceId.class), any(RoomId.class)))
+					.thenReturn(List.of());
+
+			// When
+			final List<ProductResponse> result = service.getAvailableProducts(roomId, placeId);
+
+			// Then
+			assertThat(result).isEmpty();
+			verify(productRepository).findAccessibleProducts(placeId, roomId);
+		}
+
+		@Test
+		@DisplayName("ROOM Scope 상품만 존재하는 경우 정상 조회된다")
+		void shouldReturnOnlyRoomScopedProducts() {
+			// Given
+			final Product roomProduct = Product.createRoomScoped(
+					ProductId.of(1L),
+					placeId,
+					roomId,
+					"룸 전용 상품",
+					PricingStrategy.oneTime(Money.of(BigDecimal.valueOf(10000))),
+					5
+			);
+
+			when(productRepository.findAccessibleProducts(any(PlaceId.class), any(RoomId.class)))
+					.thenReturn(List.of(roomProduct));
+
+			// When
+			final List<ProductResponse> result = service.getAvailableProducts(roomId, placeId);
+
+			// Then
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0).scope()).isEqualTo(ProductScope.ROOM);
+			assertThat(result.get(0).roomId()).isEqualTo(200L);
+		}
+
+		@Test
+		@DisplayName("RESERVATION Scope 상품만 존재하는 경우 정상 조회된다")
+		void shouldReturnOnlyReservationScopedProducts() {
+			// Given
+			final Product reservationProduct = Product.createReservationScoped(
+					ProductId.of(1L),
+					"예약 전용 상품",
+					PricingStrategy.simpleStock(Money.of(BigDecimal.valueOf(5000))),
+					50
+			);
+
+			when(productRepository.findAccessibleProducts(any(PlaceId.class), any(RoomId.class)))
+					.thenReturn(List.of(reservationProduct));
+
+			// When
+			final List<ProductResponse> result = service.getAvailableProducts(roomId, placeId);
+
+			// Then
+			assertThat(result).hasSize(1);
+			assertThat(result.get(0).scope()).isEqualTo(ProductScope.RESERVATION);
+			assertThat(result.get(0).placeId()).isNull();
+			assertThat(result.get(0).roomId()).isNull();
+		}
+
+		@Test
+		@DisplayName("Repository 호출 시 올바른 파라미터를 전달한다")
+		void shouldPassCorrectParametersToRepository() {
+			// Given
+			when(productRepository.findAccessibleProducts(placeId, roomId))
+					.thenReturn(List.of());
+
+			// When
+			service.getAvailableProducts(roomId, placeId);
+
+			// Then
+			verify(productRepository).findAccessibleProducts(placeId, roomId);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
일반 사용자가 룸 예약 시 선택 가능한 상품 목록을 조회할 수 있는 API를 추가했습니다.

## Changes
### Application Layer
- **GetAvailableProductsForRoomUseCase**: 새 UseCase 인터페이스 정의
- **GetAvailableProductsForRoomService**: UseCase 구현체, 기존 ProductRepository 활용

### Adapter Layer
- **RoomProductController**: Room 리소스 중심의 RESTful API 제공
  - Endpoint: `GET /api/v1/rooms/{roomId}/available-products?placeId={placeId}`

### Tests
- **GetAvailableProductsForRoomServiceTest**: Service 단위 테스트 (5 test cases)
- **RoomProductControllerTest**: Controller 통합 테스트 (7 test cases)

## API Specification
**Endpoint**
```
GET /api/v1/rooms/{roomId}/available-products?placeId={placeId}
```

**Response**
```json
[
  {
    "productId": 1,
    "scope": "ROOM",
    "placeId": 100,
    "roomId": 200,
    "name": "룸 전용 화이트보드",
    "pricingStrategy": { ... },
    "totalQuantity": 3
  },
  {
    "productId": 2,
    "scope": "PLACE",
    "placeId": 100,
    "roomId": null,
    "name": "공용 빔 프로젝터",
    "pricingStrategy": { ... },
    "totalQuantity": 5
  },
  {
    "productId": 3,
    "scope": "RESERVATION",
    "placeId": null,
    "roomId": null,
    "name": "음료수",
    "pricingStrategy": { ... },
    "totalQuantity": 100
  }
]
```

## Design Decisions
### Architecture Choice: Room Resource-Centric Design (Approach 2)
- RESTful 원칙 준수: Room 리소스 하위의 컬렉션으로 설계
- SOLID 원칙 준수: Single Responsibility, Open-Closed, Interface Segregation
- 확장성: 향후 Room 관련 엔드포인트 추가 시 일관성 유지

### Reusability
- 기존 `ProductRepository.findAccessibleProducts()` 활용
- 기존 `ProductResponse` DTO 재사용
- 신규 Repository 쿼리 불필요

## Test Coverage
- All tests passing
- Full build successful

## Related Issues
Closes #171