### PR TITLE
[FEAT] Add API to retrieve pricing by date with time slots

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/application/dto/response/DatePricingResponse.java
+++ b/springProject/src/main/java/com/teambind/springproject/application/dto/response/DatePricingResponse.java
@@ -1,0 +1,29 @@
+package com.teambind.springproject.application.dto.response;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+/**
+ * 특정 날짜의 시간대별 가격 응답 DTO.
+ * 시작 시간(예: "11:00")을 키로, 해당 타임슬롯의 가격을 값으로 가지는 Map을 반환합니다.
+ */
+public record DatePricingResponse(
+		Map<String, BigDecimal> timeSlotPrices
+) {
+
+	public DatePricingResponse {
+		if (timeSlotPrices == null) {
+			throw new IllegalArgumentException("Time slot prices cannot be null");
+		}
+	}
+
+	/**
+	 * 시간대별 가격 Map으로부터 Response DTO를 생성합니다.
+	 *
+	 * @param timeSlotPrices 시간대별 가격 Map (시작 시간 -> 가격)
+	 * @return DatePricingResponse
+	 */
+	public static DatePricingResponse of(final Map<String, BigDecimal> timeSlotPrices) {
+		return new DatePricingResponse(timeSlotPrices);
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/application/port/in/GetDatePricingUseCase.java
+++ b/springProject/src/main/java/com/teambind/springproject/application/port/in/GetDatePricingUseCase.java
@@ -1,0 +1,24 @@
+package com.teambind.springproject.application.port.in;
+
+import com.teambind.springproject.domain.shared.RoomId;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Map;
+
+/**
+ * 특정 날짜의 시간대별 가격 조회 Use Case.
+ */
+public interface GetDatePricingUseCase {
+
+	/**
+	 * 특정 날짜의 시간대별 가격을 조회합니다.
+	 * 시작 시간(예: "11:00")을 키로, 해당 타임슬롯의 가격을 값으로 가지는 Map을 반환합니다.
+	 *
+	 * @param roomId 룸 ID
+	 * @param date   조회할 날짜
+	 * @return 시간대별 가격 Map (시작 시간 -> 가격)
+	 * @throws IllegalStateException 가격 정책이 존재하지 않을 시
+	 */
+	Map<String, BigDecimal> getPricingByDate(RoomId roomId, LocalDate date);
+}

--- a/springProject/src/main/java/com/teambind/springproject/application/service/pricingpolicy/GetDatePricingService.java
+++ b/springProject/src/main/java/com/teambind/springproject/application/service/pricingpolicy/GetDatePricingService.java
@@ -1,0 +1,83 @@
+package com.teambind.springproject.application.service.pricingpolicy;
+
+import com.teambind.springproject.application.port.in.GetDatePricingUseCase;
+import com.teambind.springproject.application.port.out.PricingPolicyRepository;
+import com.teambind.springproject.domain.pricingpolicy.PricingPolicy;
+import com.teambind.springproject.domain.pricingpolicy.exception.PricingPolicyNotFoundException;
+import com.teambind.springproject.domain.shared.DayOfWeek;
+import com.teambind.springproject.domain.shared.Money;
+import com.teambind.springproject.domain.shared.RoomId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * 특정 날짜의 시간대별 가격 조회 서비스.
+ */
+@Service
+@Transactional(readOnly = true)
+public class GetDatePricingService implements GetDatePricingUseCase {
+
+	private static final Logger logger = LoggerFactory.getLogger(GetDatePricingService.class);
+	private static final LocalTime START_TIME = LocalTime.of(0, 0);
+	private static final LocalTime END_TIME = LocalTime.of(23, 59);
+
+	private final PricingPolicyRepository pricingPolicyRepository;
+
+	public GetDatePricingService(final PricingPolicyRepository pricingPolicyRepository) {
+		this.pricingPolicyRepository = pricingPolicyRepository;
+	}
+
+	@Override
+	public Map<String, BigDecimal> getPricingByDate(final RoomId roomId, final LocalDate date) {
+		logger.info("Fetching pricing for roomId={}, date={}", roomId.getValue(), date);
+
+		final PricingPolicy policy = pricingPolicyRepository.findById(roomId)
+				.orElseThrow(() -> new PricingPolicyNotFoundException(
+						"Pricing policy not found for roomId: " + roomId.getValue()));
+
+		final DayOfWeek dayOfWeek = DayOfWeek.from(date.getDayOfWeek());
+		final int timeSlotMinutes = policy.getTimeSlot().getMinutes();
+
+		return buildTimeSlotPrices(policy, dayOfWeek, timeSlotMinutes);
+	}
+
+	private Map<String, BigDecimal> buildTimeSlotPrices(
+			final PricingPolicy policy,
+			final DayOfWeek dayOfWeek,
+			final int timeSlotMinutes) {
+
+		final Map<String, BigDecimal> timeSlotPrices = new LinkedHashMap<>();
+		LocalTime currentTime = START_TIME;
+
+		while (currentTime.isBefore(END_TIME) || currentTime.equals(END_TIME)) {
+			final Money price = findPriceForTime(policy, dayOfWeek, currentTime);
+			timeSlotPrices.put(currentTime.toString(), price.getAmount());
+
+			currentTime = currentTime.plusMinutes(timeSlotMinutes);
+
+			if (currentTime.isAfter(END_TIME)) {
+				break;
+			}
+		}
+
+		return timeSlotPrices;
+	}
+
+	private Money findPriceForTime(
+			final PricingPolicy policy,
+			final DayOfWeek dayOfWeek,
+			final LocalTime time) {
+
+		return policy.getTimeRangePrices()
+				.findPriceForSlot(dayOfWeek, time)
+				.orElse(policy.getDefaultPrice());
+	}
+}


### PR DESCRIPTION
## Summary
Implements #173

특정 날짜를 입력받아 해당 날짜의 가격 정책을 시간대별로 반환하는 API를 추가했습니다.

## Changes
- Add `DatePricingResponse` DTO for time slot pricing response
- Add `GetDatePricingUseCase` interface for date-based pricing retrieval
- Implement `GetDatePricingService` for querying pricing by date
- Add new endpoint: `GET /api/v1/pricing-policies/{roomId}/date/{date}`

## API Specification
**Endpoint:** `GET /api/v1/pricing-policies/{roomId}/date/{date}`

**Path Parameters:**
- `roomId` (Long): Room ID (must be positive)
- `date` (LocalDate): Date in yyyy-MM-dd format

**Response Example:**
```json
{
  "timeSlotPrices": {
    "00:00": 20000,
    "00:30": 20000,
    "01:00": 20000,
    "11:00": 30000,
    "12:00": 35000,
    "13:00": 40000,
    ...
  }
}
```

## Implementation Details
- 00:00부터 23:59까지 TimeSlot 간격으로 모든 시간대의 가격을 반환
- 해당 요일과 시간에 설정된 TimeRangePrice가 있으면 해당 가격, 없으면 기본 가격 사용
- LinkedHashMap을 사용하여 시간 순서 보장

## Test Plan
- [x] Build successful
- [ ] Manual API testing
- [ ] Integration test (추후 추가 예정)