### PR TITLE
[FEAT] Add RefundCompleted event handling for inventory restoration

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/kafka/consumer/KafkaEventConsumer.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/kafka/consumer/KafkaEventConsumer.java
@@ -33,6 +33,7 @@ public class KafkaEventConsumer {
 		EVENT_TYPE_MAP.put("SlotReserved", SlotReservedEvent.class);
 		EVENT_TYPE_MAP.put("ReservationConfirmed", ReservationConfirmedEvent.class);
 		EVENT_TYPE_MAP.put("ReservationRefund", ReservationRefundEvent.class);
+		EVENT_TYPE_MAP.put("RefundCompleted", ReservationRefundEvent.class);
 	}
 
 	private final JsonUtil jsonUtil;
@@ -82,7 +83,8 @@ public class KafkaEventConsumer {
 	@KafkaListener(
 			topics = {
 					"${kafka.topics.reservation-confirmed}",
-					"${kafka.topics.reservation-refund}"
+					"${kafka.topics.reservation-refund}",
+					"${kafka.topics.refund-completed}"
 			},
 			groupId = "${spring.kafka.consumer.group-id}")
 	public void consumePaymentEvents(final String message, final Acknowledgment acknowledgment) {

--- a/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/kafka/handler/RefundCompletedEventHandler.java
+++ b/springProject/src/main/java/com/teambind/springproject/adapter/in/messaging/kafka/handler/RefundCompletedEventHandler.java
@@ -1,0 +1,58 @@
+package com.teambind.springproject.adapter.in.messaging.kafka.handler;
+
+import com.teambind.springproject.adapter.in.messaging.kafka.event.ReservationRefundEvent;
+import com.teambind.springproject.application.service.reservationpricing.ReservationPricingService;
+import com.teambind.springproject.domain.reservationpricing.exception.InvalidReservationStatusException;
+import com.teambind.springproject.domain.reservationpricing.exception.ReservationPricingNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * RefundCompleted 이벤트 핸들러.
+ * 결제 서비스에서 환불이 완료되었을 때 발행되는 이벤트를 수신하여
+ * CONFIRMED 상태의 예약을 CANCELLED로 변경하고 재고를 해제합니다.
+ */
+@Component
+@Transactional
+public class RefundCompletedEventHandler implements EventHandler<ReservationRefundEvent> {
+
+	private static final Logger logger = LoggerFactory.getLogger(RefundCompletedEventHandler.class);
+
+	private final ReservationPricingService reservationPricingService;
+
+	public RefundCompletedEventHandler(final ReservationPricingService reservationPricingService) {
+		this.reservationPricingService = reservationPricingService;
+	}
+
+	@Override
+	public void handle(final ReservationRefundEvent event) {
+		logger.info("Handling RefundCompletedEvent: reservationId={}, occurredAt={}",
+				event.getReservationId(), event.getOccurredAt());
+
+		try {
+			// 환불 처리: 재고 해제 + 상태 변경 (CONFIRMED → CANCELLED)
+			reservationPricingService.refundReservation(event.getReservationId());
+
+			logger.info("Successfully processed refund completed: reservationId={}",
+					event.getReservationId());
+
+		} catch (final ReservationPricingNotFoundException e) {
+			logger.error("Reservation not found: reservationId={}", event.getReservationId(), e);
+			throw e;
+		} catch (final InvalidReservationStatusException e) {
+			logger.error("Invalid state transition for refund: reservationId={}, message={}",
+					event.getReservationId(), e.getMessage(), e);
+			throw e;
+		} catch (final Exception e) {
+			logger.error("Failed to handle RefundCompletedEvent: {}", event, e);
+			throw new RuntimeException("Failed to handle RefundCompletedEvent", e);
+		}
+	}
+
+	@Override
+	public String getSupportedEventType() {
+		return "RefundCompleted";
+	}
+}

--- a/springProject/src/main/resources/application-dev.yaml
+++ b/springProject/src/main/resources/application-dev.yaml
@@ -107,6 +107,7 @@ kafka:
     reservation-reserved: ${KAFKA_TOPIC_RESERVATION_RESERVED:reservation-reserved}
     reservation-confirmed: ${KAFKA_TOPIC_RESERVATION_CONFIRMED:reservation-confirmed}
     reservation-refund: ${KAFKA_TOPIC_RESERVATION_REFUND:reservation-refund}
+    refund-completed: ${KAFKA_TOPIC_REFUND_COMPLETED:refund-completed}
 
     # Outbound topics (publish to other services)
     reservation-cancelled: ${KAFKA_TOPIC_RESERVATION_CANCELLED:reservation-cancelled}


### PR DESCRIPTION
## Summary
- Add RefundCompleted Kafka event consumer for refund-completed topic
- Route RefundCompleted events to RefundCompletedEventHandler
- Reuse existing refundReservation() service logic for inventory restoration

## Changes
- KafkaEventConsumer: Add RefundCompleted mapping and topic listener
- RefundCompletedEventHandler: New handler for RefundCompleted events
- application-dev.yaml: Add refund-completed topic configuration

## Test plan
- [ ] Verify RefundCompleted event is consumed from refund-completed topic
- [ ] Verify inventory is restored after event processing
- [ ] Verify reservation status changes to CANCELLED